### PR TITLE
feat(ui): report readiness for the current view instead of the whole source

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2946,7 +2946,7 @@ const SCAN_REROUTE_GROWTH = 1.4;
 // verdict and pins the routing like `routing.overridden` so a streaming
 // re-evaluation can't flip it. Per-session, reset to 'auto' on every new scan.
 // One-shot guard: re-evaluate the scan type once the streaming cloud has fully
-// settled ("Streaming ready"), so a verdict decided on a sparse early frame is
+// settled (current view ready), so a verdict decided on a sparse early frame is
 // corrected on representative geometry. Reset per scan.
 let streamingSettledRouted = false;
 // Settled-evaluation bookkeeping for the re-arming one-shot (v0.4.5b fix —
@@ -3023,7 +3023,7 @@ function treatAsDisabledFor(
  * (`settleOneShotSpent`): true once the settled verdict LANDED (the planner
  * applied it or the soft-commit fired) — or once no commit can ever come
  * (pinned / manual override) — false when the verdict was REFUSED by the
- * routing guards or the frame was undecidable, so the "Streaming ready" poll
+ * routing guards or the frame was undecidable, so the settled-view poll
  * keeps the one-shot armed and retries on fuller geometry (bounded by
  * SETTLE_RETRY_CAP). Non-settled callers ignore the value.
  */
@@ -5029,6 +5029,10 @@ function startStreamingStatusPolling(): void {
     const scheduler = viewer.streamingScheduler;
     if (!cloud || !scheduler) return;
     const counts = cloud.counts();
+    // ONE snapshot per tick: the panel line, the bar and the settle one-shot
+    // all read the same instant, and the same wanted-set verdict the renderer's
+    // phase machine acts on.
+    const diag = scheduler.diagnostics();
     streamingPanel.setStatus({
       loadedNodes: counts.resident,
       knownNodes: counts.known,
@@ -5036,19 +5040,15 @@ function startStreamingStatusPolling(): void {
       sourcePoints: cloud.sourcePointCount,
       cacheBytes: scheduler.cacheStats().byteSize,
     });
-    if (counts.resident === 0) {
-      streamingPanel.setPhase('Streaming coarse geometry…');
-    } else if (counts.loading > 0 || counts.queued > 0 || counts.decoded > 0) {
-      streamingPanel.setPhase('Refining visible detail…');
-    } else {
-      streamingPanel.setPhase('Streaming ready');
-      // First time the stream GENUINELY settles, re-evaluate the scan type on
+    streamingPanel.setViewDiagnostics(diag);
+    if (diag.readinessPhase === 'settled') {
+      // First settled current-view verdict: re-evaluate the scan type on
       // the now fully-resident cloud — a sparse early frame can misread a
       // 360 / house as terrain or object. One-shot per scan; a manual "Treat
       // as" override or a "run anyway" pin make this a no-op (and spend it).
       //
       // Two guards keep the one-shot THE settled verdict (v0.4.5 fix — the
-      // pill stayed on Auto after "Streaming ready" because a transient idle
+      // pill stayed on Auto after the ready poll because a transient idle
       // had silently spent the one-shot without committing):
       //   1. DEPTH GATE — the scheduler often reads idle at the root level
       //      (depth 0) long before the cloud fills in (same reality the

--- a/src/terrain/scanRoute.ts
+++ b/src/terrain/scanRoute.ts
@@ -56,7 +56,7 @@ export interface ScanRouteInput {
   /**
    * True when this evaluation runs on SETTLED geometry — the open-time call
    * for a static (fully loaded) file, or the one-shot re-evaluation fired
-   * when a streaming cloud reaches "Streaming ready". A settled verdict is
+   * when a streaming cloud's current view is ready. A settled verdict is
    * the one the "Treat as" control soft-commits to (see `commitDetected`);
    * sparse mid-stream frames (false) only ever route, never commit.
    */
@@ -168,7 +168,7 @@ export function planScanRoute(input: ScanRouteInput): ScanRoutePlan {
 }
 
 /**
- * The octree depth the resident set must reach before a "Streaming ready"
+ * The octree depth the resident set must reach before a current-view-ready
  * idle poll counts as GENUINELY settled — the gate in front of the streaming
  * settle one-shot (`applyScanRoute(false, true)` in `src/main.ts`).
  *
@@ -194,7 +194,7 @@ export function settleTargetDepth(hierarchyMaxDepth: number): number {
  * verdict re-arms the one-shot (see {@link settleOneShotSpent}), so without a
  * cap a scan whose gather permanently fails — or whose early-node verdict is
  * permanently refused by the no-flip guard — would re-classify on every
- * "Streaming ready" poll forever. After this many attempts the one-shot is
+ * current-view-ready poll forever. After this many attempts the one-shot is
  * spent regardless; the pill simply stays on Auto, which is the honest state.
  */
 export const SETTLE_RETRY_CAP = 40;

--- a/src/ui/StreamingPanel.ts
+++ b/src/ui/StreamingPanel.ts
@@ -15,11 +15,13 @@
 
 import { clamp01 } from '../numeric';
 import { el, formatCount } from './dom';
+import { streamingViewStatus, type StreamingViewStatus } from './streamingViewStatus';
 import { CURATED_LICENSE_LABELS, curatedCreditFor } from '../io/catalog/curatedLocations';
 import { formatByteSize as formatBytes } from '../io/formatByteSize';
 import type { ColorMode } from '../render/colorModes';
 import type { StreamingQuality } from '../render/streaming/streamingBudget';
 import type { CrsLinearUnit } from '../io/crs';
+import type { StreamingDiagnostics } from '../render/streaming/streamingDiagnostics';
 
 /**
  * The CRS facts the spacing row needs to state its unit honestly — a structural
@@ -276,9 +278,6 @@ export class StreamingPanel {
   private readonly _progressFill: HTMLElement;
   private readonly _progressNodes: HTMLElement;
   private readonly _progressPoints: HTMLElement;
-  // Sticky terminal state: once "Streaming ready" lands, the bar reads 100%
-  // and stops reacting to late jitter in the counters.
-  private _streamReady = false;
   private readonly _summary: HTMLElement;
   private readonly _nodes: HTMLElement;
   private readonly _points: HTMLElement;
@@ -314,7 +313,7 @@ export class StreamingPanel {
     this._progressFill = el('div', { className: 'olv-stream-prog-fill' });
     this._progressTrack = el('div', { className: 'olv-stream-prog-track' }, [this._progressFill]);
     this._progressTrack.setAttribute('role', 'progressbar');
-    this._progressTrack.setAttribute('aria-label', 'Resident detail loaded');
+    this._progressTrack.setAttribute('aria-label', 'Current view detail resident');
     this._progressTrack.setAttribute('aria-valuemin', '0');
     this._progressTrack.setAttribute('aria-valuemax', '100');
     this._progressNodes = el('span', { className: 'olv-stream-prog-nodes', text: '—' });
@@ -457,7 +456,6 @@ export class StreamingPanel {
     this._paused = false;
     this._pause.textContent = 'Pause';
     // Reset the progress treatment for the next scan.
-    this._streamReady = false;
     this._progress.classList.add('olv-hidden');
     this._progressTrack.classList.remove('olv-stream-prog-shimmer');
     this._progressFill.style.width = '0%';
@@ -470,13 +468,6 @@ export class StreamingPanel {
     this._gradeResult.classList.remove('olv-streaming-grade-error');
   }
 
-  /**
-   * Set the high-level load phase line.
-   *
-   * The terminal "Streaming ready" phase latches a sticky 100% on the bar
-   * (`_streamReady`) so the determinate fill reads full and stops reacting to
-   * late counter jitter; any earlier phase un-latches it.
-   */
   /**
    * Show the credit a curated source requires, for the URL being streamed.
    *
@@ -500,18 +491,51 @@ export class StreamingPanel {
     }
   }
 
+  /**
+   * Set the high-level load phase line for the OPENING stages — reading
+   * metadata, building the hierarchy — where no wanted set exists yet and the
+   * scheduler has no verdict to give. Once diagnostics exist,
+   * {@link setViewStatus} owns this line and nothing latches: readiness is a
+   * property of the current view and is revoked when that view changes.
+   */
   setPhase(phase: string): void {
     this._phase.textContent = phase;
-    const ready = phase === 'Streaming ready';
-    if (ready !== this._streamReady) {
-      this._streamReady = ready;
-      if (ready) {
-        // Full, determinate, no shimmer — the load has genuinely settled.
-        this._progress.classList.remove('olv-hidden');
-        this._progressTrack.classList.remove('olv-stream-prog-shimmer');
-        this._progressFill.style.width = '100%';
-        this._progressTrack.setAttribute('aria-valuenow', '100');
-      }
+  }
+
+  /** Whether the user has paused streaming. */
+  get paused(): boolean {
+    return this._paused;
+  }
+
+  /**
+   * Render the current-view line from ONE scheduler diagnostics snapshot. The
+   * panel holds the pause flag, so the caller passes only the snapshot and both
+   * halves of the model come from the same instant.
+   */
+  setViewDiagnostics(diagnostics: StreamingDiagnostics): void {
+    this.setViewStatus(streamingViewStatus(diagnostics, this._paused));
+  }
+
+  /**
+   * Render one current-view readiness model: the headline, the resident share
+   * of the WANTED set, and the compact counts. The whole line comes from a
+   * single snapshot, so the words and the bar always describe the same instant,
+   * and a later snapshot can move the bar back down.
+   */
+  setViewStatus(view: StreamingViewStatus): void {
+    this._phase.textContent = view.headline;
+    this._progress.classList.remove('olv-hidden');
+    this._progressNodes.textContent = view.detail;
+    if (view.determinate && view.fraction != null) {
+      this._progressTrack.classList.remove('olv-stream-prog-shimmer');
+      const pct = Math.round(view.fraction * 100);
+      this._progressFill.style.width = `${pct}%`;
+      this._progressTrack.setAttribute('aria-valuenow', String(pct));
+    } else {
+      // No wanted set — indeterminate shimmer, no fabricated percentage.
+      this._progressTrack.classList.add('olv-stream-prog-shimmer');
+      this._progressFill.style.width = '0%';
+      this._progressTrack.removeAttribute('aria-valuenow');
     }
   }
 
@@ -686,32 +710,11 @@ export class StreamingPanel {
       status.sourcePoints === null ? 'Unknown' : formatCount(status.sourcePoints)
     }`;
     this._cache.textContent = formatBytes(status.cacheBytes);
-    this._updateProgress(status);
-  }
-
-  /**
-   * Drive the progress bar from the live counters. Determinate (brand-gradient
-   * fill at resident/known fraction) when the total node count is known; the
-   * indeterminate shimmer otherwise. Once "Streaming ready" has latched, the
-   * bar stays full — the load is settled and late jitter must not pull it back.
-   */
-  private _updateProgress(status: StreamingStatus): void {
-    if (this._streamReady) return;
-    const p = streamingProgress(status);
-    this._progress.classList.remove('olv-hidden');
-    this._progressNodes.textContent = p.nodesLabel;
-    this._progressPoints.textContent = p.pointsLabel;
-    if (p.determinate && p.fraction != null) {
-      this._progressTrack.classList.remove('olv-stream-prog-shimmer');
-      const pct = Math.round(p.fraction * 100);
-      this._progressFill.style.width = `${pct}%`;
-      this._progressTrack.setAttribute('aria-valuenow', String(pct));
-    } else {
-      // Total unknown — honest indeterminate shimmer, no fabricated percentage.
-      this._progressTrack.classList.add('olv-stream-prog-shimmer');
-      this._progressFill.style.width = '0%';
-      this._progressTrack.removeAttribute('aria-valuenow');
-    }
+    // Source/cache context only. The progress bar belongs to the current view
+    // (`setViewStatus`): resident-over-known is the share of the HIERARCHY held
+    // in memory, never a download-completion percentage for a source the
+    // scheduler only ever fetches a view's worth of.
+    this._progressPoints.textContent = streamingProgress(status).pointsLabel;
   }
 
   private _statRow(label: string, value: HTMLElement): HTMLElement {

--- a/src/ui/streamingViewStatus.ts
+++ b/src/ui/streamingViewStatus.ts
@@ -1,0 +1,162 @@
+/**
+ * streamingViewStatus.ts
+ *
+ * Presentation model for the streaming panel's readiness line.
+ *
+ * WHAT THIS FIXES. The panel used to describe a view-dependent source with a
+ * GLOBAL ratio — resident nodes over every node the hierarchy knows about — and
+ * latched a terminal "ready" the moment the scheduler first went idle. Both
+ * readings mislead: a hierarchy count is not a download denominator (the
+ * scheduler never intends to fetch the whole octree), and a latch cannot be
+ * revoked, so panning to a brand-new region still read 100% while a whole new
+ * wanted set was loading.
+ *
+ * The honest quantity is the CURRENT VIEW: of the nodes the scheduler wants for
+ * the camera as it stands, how many are resident. That verdict already exists —
+ * `evaluateRefinementReadiness` derives it from wanted-set counts and the
+ * renderer's DPR phase machine acts on it. This module only INTERPRETS that
+ * verdict for display: it re-decides nothing, and introduces no threshold of
+ * its own that could let an incomplete set claim completion.
+ *
+ * Pure: numbers and strings in, one record out. No DOM, no scheduler import.
+ */
+
+import type { StreamingDiagnostics } from '../render/streaming/streamingDiagnostics';
+
+/**
+ * The displayed state.
+ *
+ * The first four mirror the canonical readiness phases one-for-one. The other
+ * two are presentation refinements over facts the verdict already carries, not
+ * new verdicts: `incomplete` is a set holding failed nodes (the readiness model
+ * calls that `'loading'` forever, which is true but does not say why), and
+ * `paused` is a set the user stopped.
+ */
+export type StreamingViewState =
+  | 'unknown'
+  | 'loading'
+  | 'settling'
+  | 'settled'
+  | 'incomplete'
+  | 'paused';
+
+/** How the line should read — never a colour, so the panel keeps its own styling. */
+export type StreamingViewTone = 'neutral' | 'progress' | 'ready' | 'warn';
+
+/** One rendering of the current-view readiness verdict. */
+export interface StreamingViewStatus {
+  readonly state: StreamingViewState;
+  /** The headline sentence for the phase line. */
+  readonly headline: string;
+  /** Resident share of the WANTED set in [0,1], or null when there is no denominator. */
+  readonly fraction: number | null;
+  /** Whether `fraction` may be drawn as a bar (false ⇒ indeterminate, no percentage). */
+  readonly determinate: boolean;
+  /** Compact counts under the headline; empty when there is nothing to count. */
+  readonly detail: string;
+  readonly tone: StreamingViewTone;
+}
+
+/** "N requested node" / "N requested nodes" — the counts are small and exact. */
+function nodes(n: number): string {
+  return `${n} requested node${n === 1 ? '' : 's'}`;
+}
+
+/**
+ * Interpret one streaming-diagnostics snapshot as a current-view readout.
+ *
+ * Precedence, and why:
+ *  1. no wanted set (`wantedNodes === 0`) → `unknown`. Nothing is wanted, so
+ *     there is nothing to be ready about and no denominator to be a percentage
+ *     of. Indeterminate, with no fabricated fraction — this holds even while
+ *     paused, because a paused view with no wanted set has nothing to report.
+ *  2. `failedNodes > 0` → `incomplete`, whatever the phase says. A set that
+ *     cannot complete must never present as ready, and the count of nodes that
+ *     could not load is the fact the user needs; the real resident share is
+ *     preserved beside it.
+ *  3. paused → `paused`. A stopped load is not a failed one, and the two must
+ *     not be told with the same words.
+ *  4. otherwise the canonical phase, verbatim.
+ *
+ * `settled` means every wanted node is resident with nothing queued, in flight
+ * or awaiting commit, and none failed. It does NOT mean the source finished
+ * downloading; no wording here says it does.
+ *
+ * @param diagnostics one snapshot — take it ONCE per tick so every surface
+ * describes the same instant.
+ * @param paused whether the user has paused streaming.
+ */
+export function streamingViewStatus(
+  diagnostics: StreamingDiagnostics,
+  paused: boolean,
+): StreamingViewStatus {
+  const wanted = diagnostics.wantedNodes;
+  if (wanted === 0) {
+    return {
+      state: 'unknown',
+      headline: 'Establishing current view…',
+      fraction: null,
+      determinate: false,
+      detail: '',
+      tone: 'neutral',
+    };
+  }
+
+  const resident = Math.min(diagnostics.residentNodes, wanted);
+  // Read from the snapshot when the scheduler stated it, so the bar and the
+  // renderer's phase machine cannot disagree by a rounding step.
+  const fraction = diagnostics.fractionResident ?? resident / wanted;
+  const detail = `${resident} / ${wanted} requested nodes resident`;
+
+  if (diagnostics.failedNodes > 0) {
+    return {
+      state: 'incomplete',
+      headline: `Current view incomplete — ${nodes(diagnostics.failedNodes)} could not load`,
+      fraction,
+      determinate: true,
+      detail,
+      tone: 'warn',
+    };
+  }
+
+  if (paused) {
+    return {
+      state: 'paused',
+      headline: 'Paused',
+      fraction,
+      determinate: true,
+      detail,
+      tone: 'neutral',
+    };
+  }
+
+  switch (diagnostics.readinessPhase) {
+    case 'settled':
+      return {
+        state: 'settled',
+        headline: 'Current view ready',
+        fraction,
+        determinate: true,
+        detail,
+        tone: 'ready',
+      };
+    case 'settling':
+      return {
+        state: 'settling',
+        headline: 'Refining current view…',
+        fraction,
+        determinate: true,
+        detail,
+        tone: 'progress',
+      };
+    default:
+      return {
+        state: 'loading',
+        headline: 'Loading current view…',
+        fraction,
+        determinate: true,
+        detail,
+        tone: 'progress',
+      };
+  }
+}

--- a/tests/currentViewReadiness.test.ts
+++ b/tests/currentViewReadiness.test.ts
@@ -1,0 +1,165 @@
+/**
+ * currentViewReadiness.test.ts
+ *
+ * The current-view readout: `streamingViewStatus` turns ONE streaming
+ * diagnostics snapshot into the panel's headline, fraction and detail.
+ *
+ * The contract under test is that the panel describes the WANTED set — the
+ * nodes the scheduler selected for the camera as it stands — and nothing else.
+ * A resident/known hierarchy ratio is not a completion percentage for a
+ * view-dependent source, a failed node can never read as ready, and a settled
+ * view whose wanted set then grows must fall back below 100% (there is no
+ * latch to hold it up).
+ *
+ * The last case pins the shared authority: the same
+ * `SchedulerReadinessFacts` that the renderer's phase machine evaluates is what
+ * the panel line is derived from, so the two can never disagree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { streamingViewStatus } from '../src/ui/streamingViewStatus';
+import {
+  buildStreamingDiagnostics,
+  type StreamingDiagnostics,
+} from '../src/render/streaming/streamingDiagnostics';
+import {
+  evaluateRefinementReadiness,
+  type SchedulerReadinessFacts,
+} from '../src/render/streaming/refinementReadiness';
+
+/** Neutral values for every quantity this readout does not read. */
+const EXTRA = {
+  knownNodes: 4096,
+  visibleNodes: 0,
+  residentPoints: 0,
+  decodedPendingPoints: 0,
+  pointBudget: 1_000_000,
+  lastTickMs: 1,
+  cameraVelocity: 0,
+  cameraStable: true,
+  effectiveMaxConcurrent: 4,
+  pressureDepthReduction: 0,
+  fpsBudgetFactor: 1,
+  fullRescoreCount: 0,
+  cacheBytes: 0,
+  cacheEntries: 0,
+  cacheMaxBytes: 1,
+  cacheHits: 0,
+  cacheMisses: 0,
+  cacheEvictions: 0,
+};
+
+/** Build a snapshot the way the scheduler does: one verdict, from the facts. */
+function snapshot(facts: Partial<SchedulerReadinessFacts>): StreamingDiagnostics {
+  const full: SchedulerReadinessFacts = {
+    wantedCount: 0,
+    residentCount: 0,
+    inFlightCount: 0,
+    queuedCount: 0,
+    decodedPendingCount: 0,
+    failedCount: 0,
+    ...facts,
+  };
+  return buildStreamingDiagnostics(full, evaluateRefinementReadiness(full), EXTRA);
+}
+
+describe('streamingViewStatus — the current view, not the whole source', () => {
+  it('refuses a verdict with no wanted set: indeterminate, no fabricated percentage', () => {
+    const v = streamingViewStatus(snapshot({ wantedCount: 0 }), false);
+    expect(v.state).toBe('unknown');
+    expect(v.determinate).toBe(false);
+    expect(v.fraction).toBeNull();
+    expect(v.headline).toBe('Establishing current view…');
+  });
+
+  it('reports a loading view as resident-over-wanted', () => {
+    const v = streamingViewStatus(
+      snapshot({ wantedCount: 10, residentCount: 4, queuedCount: 3, inFlightCount: 3 }),
+      false,
+    );
+    expect(v.state).toBe('loading');
+    expect(v.headline).toBe('Loading current view…');
+    expect(v.fraction).toBeCloseTo(0.4, 10);
+    expect(v.detail).toBe('4 / 10 requested nodes resident');
+  });
+
+  it('reports a tail still landing as refining', () => {
+    const v = streamingViewStatus(
+      snapshot({ wantedCount: 20, residentCount: 19, decodedPendingCount: 1 }),
+      false,
+    );
+    expect(v.state).toBe('settling');
+    expect(v.headline).toBe('Refining current view…');
+    expect(v.fraction).toBeCloseTo(0.95, 10);
+  });
+
+  it('calls a fully resident wanted set ready, at a real 100%', () => {
+    const v = streamingViewStatus(snapshot({ wantedCount: 20, residentCount: 20 }), false);
+    expect(v.state).toBe('settled');
+    expect(v.headline).toBe('Current view ready');
+    expect(v.fraction).toBe(1);
+  });
+
+  it('never reads as ready while a wanted node has failed', () => {
+    const v = streamingViewStatus(
+      snapshot({ wantedCount: 20, residentCount: 19, failedCount: 1 }),
+      false,
+    );
+    expect(v.state).toBe('incomplete');
+    expect(v.headline).toBe('Current view incomplete — 1 requested node could not load');
+    expect(v.headline).not.toMatch(/ready/);
+    expect(v.fraction).toBeCloseTo(0.95, 10);
+  });
+
+  it('pluralises the failed-node count', () => {
+    const v = streamingViewStatus(
+      snapshot({ wantedCount: 20, residentCount: 18, failedCount: 2 }),
+      false,
+    );
+    expect(v.headline).toBe('Current view incomplete — 2 requested nodes could not load');
+  });
+
+  it('tells a paused view apart from a failed one', () => {
+    const v = streamingViewStatus(
+      snapshot({ wantedCount: 10, residentCount: 6, queuedCount: 4 }),
+      true,
+    );
+    expect(v.state).toBe('paused');
+    expect(v.headline).toBe('Paused');
+    expect(v.tone).not.toBe('warn');
+    expect(v.detail).toBe('6 / 10 requested nodes resident');
+  });
+
+  it('falls back below 100% when a settled view acquires a new wanted set', () => {
+    const settled = streamingViewStatus(snapshot({ wantedCount: 20, residentCount: 20 }), false);
+    expect(settled.fraction).toBe(1);
+    // The camera moved: the scheduler now wants 50 nodes and holds the 20 it had.
+    const moved = streamingViewStatus(
+      snapshot({ wantedCount: 50, residentCount: 20, queuedCount: 30 }),
+      false,
+    );
+    expect(moved.state).toBe('loading');
+    expect(moved.fraction).toBeCloseTo(0.4, 10);
+    expect(moved.headline).not.toBe('Current view ready');
+  });
+
+  it('derives its state from the SAME facts the renderer phase machine evaluates', () => {
+    const facts: SchedulerReadinessFacts = {
+      wantedCount: 30,
+      residentCount: 29,
+      inFlightCount: 1,
+      queuedCount: 0,
+      decodedPendingCount: 0,
+      failedCount: 0,
+    };
+    const rendererVerdict = evaluateRefinementReadiness(facts);
+    const panel = streamingViewStatus(
+      buildStreamingDiagnostics(facts, rendererVerdict, EXTRA),
+      false,
+    );
+    expect(panel.state).toBe(rendererVerdict.phase);
+    expect(panel.fraction).toBe(
+      rendererVerdict.phase === 'unknown' ? null : rendererVerdict.fractionResident,
+    );
+  });
+});

--- a/tests/e2e/streaming.spec.ts
+++ b/tests/e2e/streaming.spec.ts
@@ -97,7 +97,7 @@ test('opens a real COPC file and streams it progressively', async ({ page }) => 
   await expect(panel).toBeVisible({ timeout: 60_000 });
 
   // Nodes stream in — the panel reaches a refining or ready phase.
-  await expect(panel).toContainText(/Refining|Streaming ready/, { timeout: 60_000 });
+  await expect(panel).toContainText(/Refining current view|Current view ready/, { timeout: 60_000 });
 
   // The empty state is gone and navigation is live.
   await expect(page.locator('.olv-empty')).toBeHidden();
@@ -124,7 +124,7 @@ test('inspects a per-point readout on a streaming COPC node', async ({ page }) =
   const panel = page.locator('.olv-streaming-panel');
   await expect(panel).toBeVisible({ timeout: 60_000 });
   // Wait for resident nodes to refine so the meshes are dense enough to hit.
-  await expect(panel).toContainText(/Refining|Streaming ready/, { timeout: 60_000 });
+  await expect(panel).toContainText(/Refining current view|Current view ready/, { timeout: 60_000 });
   await page.waitForTimeout(2_500); // let the framing tween settle
 
   // Enter the Inspect tool — enabled on a streaming scan in v0.3.0.

--- a/tests/e2e/streamingCaveat.spec.ts
+++ b/tests/e2e/streamingCaveat.spec.ts
@@ -39,7 +39,7 @@ test.describe('streaming-resident caveat caption (autzen COPC required)', () => 
     // The streaming panel appears once metadata + hierarchy are read.
     const panel = page.locator('.olv-streaming-panel');
     await expect(panel).toBeVisible({ timeout: 60_000 });
-    await expect(panel).toContainText(/Refining|Streaming ready/, { timeout: 60_000 });
+    await expect(panel).toContainText(/Refining current view|Current view ready/, { timeout: 60_000 });
 
     // Enter measurement mode and pick the Profile kind. The profile
     // sampler needs two points; we drop them at deterministic NDC

--- a/tests/panelViewStatus.test.ts
+++ b/tests/panelViewStatus.test.ts
@@ -13,71 +13,9 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import type { StreamingViewStatus } from '../src/ui/streamingViewStatus';
+import { installFakeDom, byClass, findContaining, type FakeEl } from './support/measurePanelDom';
 
-class FakeEl {
-  className = '';
-  title = '';
-  type = '';
-  disabled = false;
-  private _text = '';
-  readonly attrs: Record<string, string> = {};
-  readonly children: FakeEl[] = [];
-  readonly dataset: Record<string, string> = {};
-  readonly style: Record<string, string> = {};
-  readonly classList = {
-    _set: new Set<string>(),
-    add(c: string): void { this._set.add(c); },
-    remove(c: string): void { this._set.delete(c); },
-    toggle(c: string, on?: boolean): void {
-      const want = on ?? !this._set.has(c);
-      if (want) this._set.add(c); else this._set.delete(c);
-    },
-    contains(c: string): boolean { return this._set.has(c); },
-  };
-  readonly tagName: string;
-  constructor(tagName: string) { this.tagName = tagName; }
-  setAttribute(k: string, v: string): void { this.attrs[k] = v; }
-  removeAttribute(k: string): void { delete this.attrs[k]; }
-  set textContent(v: string) { this._text = v; }
-  get textContent(): string {
-    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
-  }
-  append(...kids: FakeEl[]): void { this.children.push(...kids.filter(Boolean)); }
-  replaceChildren(...kids: FakeEl[]): void {
-    this.children.length = 0;
-    this.children.push(...kids.filter(Boolean));
-  }
-  addEventListener(): void { /* no-op */ }
-  blur(): void { /* no-op */ }
-  click(): void { /* no-op */ }
-  /** First descendant carrying `cls`, or undefined. */
-  byClass(cls: string): FakeEl | undefined {
-    if (this.className.split(' ').includes(cls)) return this;
-    for (const c of this.children) {
-      const hit = c.byClass(cls);
-      if (hit) return hit;
-    }
-    return undefined;
-  }
-  /** First descendant whose own text contains `substr`, or undefined. */
-  findContaining(substr: string): FakeEl | undefined {
-    if (this._text.includes(substr)) return this;
-    for (const c of this.children) {
-      const hit = c.findContaining(substr);
-      if (hit) return hit;
-    }
-    return undefined;
-  }
-}
-
-beforeAll(() => {
-  (globalThis as unknown as { document: unknown }).document = {
-    createElement: (tag: string) => new FakeEl(tag),
-  };
-  const g = globalThis as unknown as Record<string, unknown>;
-  g.HTMLInputElement ??= class {};
-  g.HTMLAnchorElement ??= class {};
-});
+beforeAll(installFakeDom);
 
 function noopCallbacks() {
   return {
@@ -108,10 +46,10 @@ describe('StreamingPanel — current-view readiness line', () => {
   it('renders the headline, the detail and a determinate fill', async () => {
     const { panel, root } = await makePanel();
     panel.setViewStatus(model({}));
-    expect(root.findContaining('Loading current view…')).toBeDefined();
-    expect(root.findContaining('5 / 10 requested nodes resident')).toBeDefined();
-    expect(root.byClass('olv-stream-prog-fill')?.style.width).toBe('50%');
-    expect(root.byClass('olv-stream-prog-track')?.attrs['aria-valuenow']).toBe('50');
+    expect(findContaining(root, 'Loading current view…')).toBeDefined();
+    expect(findContaining(root, '5 / 10 requested nodes resident')).toBeDefined();
+    expect(byClass(root, 'olv-stream-prog-fill')?.style.width).toBe('50%');
+    expect(byClass(root, 'olv-stream-prog-track')?.getAttribute('aria-valuenow')).toBe('50');
   });
 
   it('shows no percentage at all when the view is indeterminate', async () => {
@@ -119,9 +57,10 @@ describe('StreamingPanel — current-view readiness line', () => {
     panel.setViewStatus(
       model({ state: 'unknown', headline: 'Establishing current view…', fraction: null, determinate: false, detail: '' }),
     );
-    const track = root.byClass('olv-stream-prog-track');
+    const track = byClass(root, 'olv-stream-prog-track');
     expect(track?.classList.contains('olv-stream-prog-shimmer')).toBe(true);
-    expect(track?.attrs['aria-valuenow']).toBeUndefined();
+    // getAttribute follows DOM semantics: a removed attribute reads null.
+    expect(track?.getAttribute('aria-valuenow')).toBeNull();
   });
 
   it('revokes ready when the next snapshot reports a new wanted set', async () => {
@@ -129,13 +68,13 @@ describe('StreamingPanel — current-view readiness line', () => {
     panel.setViewStatus(
       model({ state: 'settled', headline: 'Current view ready', fraction: 1, detail: '20 / 20 requested nodes resident', tone: 'ready' }),
     );
-    expect(root.byClass('olv-stream-prog-fill')?.style.width).toBe('100%');
+    expect(byClass(root, 'olv-stream-prog-fill')?.style.width).toBe('100%');
 
     // Camera moved: 50 wanted, 20 resident. Nothing may hold the bar at 100%.
     panel.setViewStatus(model({ fraction: 0.4, detail: '20 / 50 requested nodes resident' }));
-    expect(root.byClass('olv-stream-prog-fill')?.style.width).toBe('40%');
-    expect(root.findContaining('Current view ready')).toBeUndefined();
-    expect(root.findContaining('20 / 50 requested nodes resident')).toBeDefined();
+    expect(byClass(root, 'olv-stream-prog-fill')?.style.width).toBe('40%');
+    expect(findContaining(root, 'Current view ready')).toBeUndefined();
+    expect(findContaining(root, '20 / 50 requested nodes resident')).toBeDefined();
   });
 
   it('marks a view holding failed nodes without ever saying ready', async () => {
@@ -149,9 +88,9 @@ describe('StreamingPanel — current-view readiness line', () => {
         tone: 'warn',
       }),
     );
-    expect(root.findContaining('Current view incomplete — 2 requested nodes could not load')).toBeDefined();
-    expect(root.findContaining('Current view ready')).toBeUndefined();
-    expect(root.byClass('olv-stream-prog-fill')?.style.width).toBe('90%');
+    expect(findContaining(root, 'Current view incomplete — 2 requested nodes could not load')).toBeDefined();
+    expect(findContaining(root, 'Current view ready')).toBeUndefined();
+    expect(byClass(root, 'olv-stream-prog-fill')?.style.width).toBe('90%');
   });
 
   it('reports whether the user has paused streaming', async () => {

--- a/tests/panelViewStatus.test.ts
+++ b/tests/panelViewStatus.test.ts
@@ -1,0 +1,161 @@
+/**
+ * panelViewStatus.test.ts
+ *
+ * `StreamingPanel.setViewStatus` renders the current-view model and nothing
+ * else decides the bar. The guard that matters is reversibility: the old panel
+ * latched a terminal 100% on the phase string "Streaming ready" and early-
+ * returned from every later update, so a camera move into unloaded terrain
+ * still read complete. Ready must now be revocable by the next snapshot.
+ *
+ * Runs in the node environment on the same recording DOM stub the other panel
+ * tests use.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { StreamingViewStatus } from '../src/ui/streamingViewStatus';
+
+class FakeEl {
+  className = '';
+  title = '';
+  type = '';
+  disabled = false;
+  private _text = '';
+  readonly attrs: Record<string, string> = {};
+  readonly children: FakeEl[] = [];
+  readonly dataset: Record<string, string> = {};
+  readonly style: Record<string, string> = {};
+  readonly classList = {
+    _set: new Set<string>(),
+    add(c: string): void { this._set.add(c); },
+    remove(c: string): void { this._set.delete(c); },
+    toggle(c: string, on?: boolean): void {
+      const want = on ?? !this._set.has(c);
+      if (want) this._set.add(c); else this._set.delete(c);
+    },
+    contains(c: string): boolean { return this._set.has(c); },
+  };
+  readonly tagName: string;
+  constructor(tagName: string) { this.tagName = tagName; }
+  setAttribute(k: string, v: string): void { this.attrs[k] = v; }
+  removeAttribute(k: string): void { delete this.attrs[k]; }
+  set textContent(v: string) { this._text = v; }
+  get textContent(): string {
+    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
+  }
+  append(...kids: FakeEl[]): void { this.children.push(...kids.filter(Boolean)); }
+  replaceChildren(...kids: FakeEl[]): void {
+    this.children.length = 0;
+    this.children.push(...kids.filter(Boolean));
+  }
+  addEventListener(): void { /* no-op */ }
+  blur(): void { /* no-op */ }
+  click(): void { /* no-op */ }
+  /** First descendant carrying `cls`, or undefined. */
+  byClass(cls: string): FakeEl | undefined {
+    if (this.className.split(' ').includes(cls)) return this;
+    for (const c of this.children) {
+      const hit = c.byClass(cls);
+      if (hit) return hit;
+    }
+    return undefined;
+  }
+  /** First descendant whose own text contains `substr`, or undefined. */
+  findContaining(substr: string): FakeEl | undefined {
+    if (this._text.includes(substr)) return this;
+    for (const c of this.children) {
+      const hit = c.findContaining(substr);
+      if (hit) return hit;
+    }
+    return undefined;
+  }
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { document: unknown }).document = {
+    createElement: (tag: string) => new FakeEl(tag),
+  };
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.HTMLInputElement ??= class {};
+  g.HTMLAnchorElement ??= class {};
+});
+
+function noopCallbacks() {
+  return {
+    onColorMode() {}, onQuality() {}, onPauseToggle() {}, onClearCache() {},
+    onGradeFullCloud() {}, onCancelGrade() {},
+  };
+}
+
+function model(over: Partial<StreamingViewStatus>): StreamingViewStatus {
+  return {
+    state: 'loading',
+    headline: 'Loading current view…',
+    fraction: 0.5,
+    determinate: true,
+    detail: '5 / 10 requested nodes resident',
+    tone: 'progress',
+    ...over,
+  };
+}
+
+async function makePanel() {
+  const { StreamingPanel } = await import('../src/ui/StreamingPanel');
+  const panel = new StreamingPanel(noopCallbacks());
+  return { panel, root: panel.element as unknown as FakeEl };
+}
+
+describe('StreamingPanel — current-view readiness line', () => {
+  it('renders the headline, the detail and a determinate fill', async () => {
+    const { panel, root } = await makePanel();
+    panel.setViewStatus(model({}));
+    expect(root.findContaining('Loading current view…')).toBeDefined();
+    expect(root.findContaining('5 / 10 requested nodes resident')).toBeDefined();
+    expect(root.byClass('olv-stream-prog-fill')?.style.width).toBe('50%');
+    expect(root.byClass('olv-stream-prog-track')?.attrs['aria-valuenow']).toBe('50');
+  });
+
+  it('shows no percentage at all when the view is indeterminate', async () => {
+    const { panel, root } = await makePanel();
+    panel.setViewStatus(
+      model({ state: 'unknown', headline: 'Establishing current view…', fraction: null, determinate: false, detail: '' }),
+    );
+    const track = root.byClass('olv-stream-prog-track');
+    expect(track?.classList.contains('olv-stream-prog-shimmer')).toBe(true);
+    expect(track?.attrs['aria-valuenow']).toBeUndefined();
+  });
+
+  it('revokes ready when the next snapshot reports a new wanted set', async () => {
+    const { panel, root } = await makePanel();
+    panel.setViewStatus(
+      model({ state: 'settled', headline: 'Current view ready', fraction: 1, detail: '20 / 20 requested nodes resident', tone: 'ready' }),
+    );
+    expect(root.byClass('olv-stream-prog-fill')?.style.width).toBe('100%');
+
+    // Camera moved: 50 wanted, 20 resident. Nothing may hold the bar at 100%.
+    panel.setViewStatus(model({ fraction: 0.4, detail: '20 / 50 requested nodes resident' }));
+    expect(root.byClass('olv-stream-prog-fill')?.style.width).toBe('40%');
+    expect(root.findContaining('Current view ready')).toBeUndefined();
+    expect(root.findContaining('20 / 50 requested nodes resident')).toBeDefined();
+  });
+
+  it('marks a view holding failed nodes without ever saying ready', async () => {
+    const { panel, root } = await makePanel();
+    panel.setViewStatus(
+      model({
+        state: 'incomplete',
+        headline: 'Current view incomplete — 2 requested nodes could not load',
+        fraction: 0.9,
+        detail: '18 / 20 requested nodes resident',
+        tone: 'warn',
+      }),
+    );
+    expect(root.findContaining('Current view incomplete — 2 requested nodes could not load')).toBeDefined();
+    expect(root.findContaining('Current view ready')).toBeUndefined();
+    expect(root.byClass('olv-stream-prog-fill')?.style.width).toBe('90%');
+  });
+
+  it('reports whether the user has paused streaming', async () => {
+    const { panel } = await makePanel();
+    expect(panel.paused).toBe(false);
+  });
+});

--- a/tests/streamingSettleCommit.test.ts
+++ b/tests/streamingSettleCommit.test.ts
@@ -6,7 +6,7 @@
  * reason — i.e. the settled verdict IS interior — yet the SELECTED segment is
  * still Auto. The settled soft-commit never landed.
  *
- * Root cause: the "Streaming ready" poll fired the settle one-shot on the
+ * Root cause: the settled-view poll fired the settle one-shot on the
  * FIRST scheduler-idle frame and spent it unconditionally. The scheduler
  * often reads idle at the root level (depth 0) long before the cloud fills
  * in, so the one-shot ran on a sparse frame whose verdict was terrain
@@ -107,7 +107,7 @@ function seg(root: FakeEl, value: ScanTypeOverride): FakeEl {
 /**
  * A miniature of the `src/main.ts` host: the exact `applyScanRoute` wiring —
  * planner call, commit application, `setScanType` mirroring, spend decision —
- * plus the "Streaming ready" poll's depth-gated one-shot. The planner, the
+ * plus the settled-view poll's depth-gated one-shot. The planner, the
  * spend rule, the depth gate, and the control are the REAL modules; only the
  * geometry gather is replaced by the verdict the classifier would return.
  */
@@ -175,7 +175,7 @@ function makeHost(control: ScanTypeControl) {
     );
     return spent;
   }
-  /** The "Streaming ready" poll's one-shot: depth gate + change-gated retry. */
+  /** The settled-view poll's one-shot: depth gate + change-gated retry. */
   function readyPoll(
     cloud: { hierarchyMaxDepth: number; deepestResident: number; residentPoints?: number },
     detected: SpaceKind | null,

--- a/tests/support/measurePanelDom.ts
+++ b/tests/support/measurePanelDom.ts
@@ -83,6 +83,10 @@ export class FakeEl {
   setAttribute(n: string, v: string): void {
     this.attrs.set(n, v);
   }
+  removeAttribute(n: string): void {
+    this.attrs.delete(n);
+  }
+
   hasAttribute(n: string): boolean {
     return this.attrs.has(n);
   }
@@ -154,3 +158,26 @@ export function installFakeDom(): void {
   g.ResizeObserver = FakeResizeObserver;
 }
 
+/**
+ * First descendant (or `root` itself) carrying `cls` in its className, else
+ * undefined. Shared by the panel tests so each one does not re-declare a DOM
+ * stub; the recording `FakeEl` above is the single implementation.
+ */
+export function byClass(root: FakeEl, cls: string): FakeEl | undefined {
+  if (root.className.split(' ').includes(cls)) return root;
+  for (const child of root.children) {
+    const hit = byClass(child, cls);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/** First descendant whose own text contains `substr`, else undefined. */
+export function findContaining(root: FakeEl, substr: string): FakeEl | undefined {
+  if (typeof root.textContent === 'string' && root.textContent.includes(substr)) return root;
+  for (const child of root.children) {
+    const hit = findContaining(child, substr);
+    if (hit) return hit;
+  }
+  return undefined;
+}


### PR DESCRIPTION
The streaming panel reported readiness for the whole source and latched it. `_streamReady` stuck at 100% once "Streaming ready" appeared, so moving the camera to a new region still presented as complete while an entirely new wanted set loaded. The bar was driven by global `loadedNodes / knownNodes`, which is not a completion measure for a view-dependent source.

The panel now renders one `scheduler.diagnostics()` snapshot per tick, from the same `evaluateRefinementReadiness` verdict the renderer consumes. New pure model `streamingViewStatus(diagnostics, paused)` maps that verdict to words and adds no threshold of its own: establishing, loading, refining, ready, incomplete, paused. A failed wanted node never reads ready. Hierarchy and cache rows remain, labelled as source context.

Tests: `currentViewReadiness` (9), `panelViewStatus` (5), which reuses the shared panel DOM stub rather than re-declaring one.
