### PR TITLE
feat(streaming): order within-level refinement toward the viewed centre

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -197,8 +197,14 @@ that must touch nothing but the pose (`tests/viewStateCoordinator.test.ts`). The
 field order and the present/absent guards stay in `src/io/viewState.ts`.
 `main.ts` keeps five thin delegates and the deps object.
 
-**`src/render/Viewer.ts` (6,418)** — the constructor and a handful of large
+**`src/render/Viewer.ts` (6,409)** — the constructor and a handful of large
 methods dominate:
+
+The count fell by 9 with the refinement-phase seam: the P6 phase bookkeeping —
+the park timestamp, the readiness-verdict mapping and the transition call — was
+inline in the adaptive-DPR branch, so it advanced only when DPR did. It now
+lives in `src/render/refinementPhaseState.ts`, which the Viewer advances every
+frame and both consumers (DPR, the streaming scheduler) read.
 
 The count fell by 37 with the profile seam. The constructor held the whole
 profile-sampler walk — eligibility, the streaming gate, the buffer

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
@@ -8,7 +8,7 @@ Five products reach E4 this cycle: `CRS-UTM-PROJECTION` (new), `CHANGE-RASTER` a
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,529 lines and `src/render/Viewer.ts` is 6,418, against stated targets of 2,500 and 2,000. The composition root shrank as the terrain-compute-path read moved into `src/app/terrainComputePath.ts`. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,529 lines and `src/render/Viewer.ts` is 6,409, against stated targets of 2,500 and 2,000. The composition root shrank as the terrain-compute-path read moved into `src/app/terrainComputePath.ts`. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
 
 ## Out-of-core streaming holds the index, not the whole cloud
 

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -5,7 +5,7 @@
       "goal": 2500
     },
     "src/render/Viewer.ts": {
-      "lines": 6418,
+      "lines": 6409,
       "goal": 2000
     }
   }

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -108,11 +108,7 @@ import {
   DPR_FULL_REDUCTION_ANGULAR,
 } from './adaptiveDpr';
 import { maxPixelRatio } from './quality/pixelRatioCeiling';
-import {
-  nextRefinementPhase,
-  phaseDprScale,
-  type RefinementPhase,
-} from './refinementPhase';
+import { RefinementPhaseTracker } from './refinementPhaseState';
 import { evaluateRefinementReadiness } from './streaming/refinementReadiness';
 import type { RefinementReadiness } from './streaming/refinementReadiness';
 import { readDevFlags } from '../perf/devFlags';
@@ -527,14 +523,6 @@ const QUAD_INDEX = [0, 1, 2, 0, 2, 3];
  * the streaming scheduler keeps its cadence — only the actual
  * GPU `render()` call is gated.
  */
-/**
- * P6 proxy (until the P4 scheduler emits real coverage / spacing signals): ms
- * after the camera parks at which the center is treated as "refined", so the
- * refinement phase reaches `full-refine` and DPR steps up to full resolution.
- * Kept short so the view re-sharpens promptly after navigation stops.
- */
-const PHASE_CENTER_PROXY_MS = 250;
-
 /** Default vertical field of view, in degrees — the camera's construction value. */
 const DEFAULT_FOV = 60;
 
@@ -816,10 +804,12 @@ export class Viewer {
   private _lastDprChangeMs = 0;
   /** `?refinementPhase` dev flag (default on) — drive DPR by discrete phases (P6). */
   private readonly _refinementPhasesEnabled: boolean = readDevFlags().refinementPhase;
-  /** Current P6 refinement phase. */
-  private _phase: RefinementPhase = 'moving';
-  /** performance.now() when the camera last parked (0 while moving). */
-  private _settledAtMs = 0;
+  /**
+   * The single P6 refinement-phase state. Advanced once per frame regardless of
+   * the DPR decision, and read by both consumers — adaptive DPR here and the
+   * streaming scheduler in `_tickStreaming`.
+   */
+  private readonly _phases = new RefinementPhaseTracker();
   /**
    * Performance timestamp until which the renderer stays at full
    * rAF rate. Bumped on every user input via `_bumpRenderActivity`.
@@ -6158,10 +6148,17 @@ export class Viewer {
     // tells the scheduler to skip FPS adaptation until real measurements
     // arrive (i.e., during the first few RAF ticks).
     const frameMs = this._smoothedFrameMs();
+    // P6 — hand the scheduler the live phase and the viewport it should measure
+    // "centre" against. Gated on the same `?refinementPhase` flag that gates the
+    // DPR consumer, so one flag turns the whole phase behaviour off.
+    const canvas = this._canvas;
     this._streaming.scheduler.update({
       viewProjection: this._streamingViewProj.elements,
       cameraPosition: this._streamingCamPos,
       frameTimeMs: frameMs > 0 ? frameMs : undefined,
+      refinementPhase: this._refinementPhasesEnabled ? this._phases.phase : undefined,
+      viewportWidthPx: canvas.clientWidth,
+      viewportHeightPx: canvas.clientHeight,
     });
   }
 
@@ -6222,7 +6219,10 @@ export class Viewer {
   }
 
   /**
-   * P5 — set the renderer's device-pixel-ratio for this frame. Full resolution
+   * Advance the P6 refinement phase, then set the renderer's device-pixel-ratio
+   * for this frame from it. The phase advances on EVERY call — the scheduler
+   * reads it too — while the DPR half is skipped unless the frame renders and
+   * the `?adaptiveDpr` flag is on. Full resolution
    * when parked; a reduced ratio while moving, driven by the camera's angular
    * speed (the P3 signal). `setPixelRatio` reallocates the drawing buffer, so
    * `shouldApplyDpr` sharpens immediately on park but rate-limits reductions.
@@ -6230,7 +6230,19 @@ export class Viewer {
    * to desync with the resize handler). No-op unless the frame renders and the
    * `?adaptiveDpr` flag is on; DPR-only, so it is camera-agnostic (ortho-safe).
    */
-  private _applyAdaptiveDpr(moving: boolean, dt: number, nowMs: number, rendered: boolean): void {
+  private _updateRefinementAndDpr(
+    moving: boolean,
+    dt: number,
+    nowMs: number,
+    rendered: boolean,
+  ): void {
+    // Phase bookkeeping first, and unconditionally: the streaming scheduler
+    // reads the phase on ticks this method returns early from.
+    const phase = this._phases.advance({
+      moving,
+      nowMs,
+      readiness: this.refinementReadiness(),
+    });
     if (!this._adaptiveDpr || !rendered) return;
     const q = this._camera.quaternion;
     this._curCamQuat[0] = q.x;
@@ -6253,33 +6265,12 @@ export class Viewer {
 
     let target: number;
     if (this._refinementPhasesEnabled) {
-      // P6 — step DPR by discrete refinement phase. With a streaming scheduler
-      // active the coverage / central-refine signals come from the WANTED-SET
-      // readiness verdict, so full resolution is reached only when the requested
-      // nodes are resident, not after a fixed time over a half-loaded cloud.
-      // Without a verdict (static cloud, or before the first cull) the
-      // elapsed-time proxy stands in; there is nothing to wait on there.
-      if (moving) this._settledAtMs = 0;
-      else if (this._settledAtMs === 0) this._settledAtMs = nowMs;
-      const msSinceSettle = moving ? 0 : nowMs - this._settledAtMs;
-      const readiness = this.refinementReadiness();
-      const coverageComplete =
-        readiness && readiness.phase !== 'unknown'
-          ? readiness.phase === 'settling' || readiness.phase === 'settled'
-          : msSinceSettle >= SETTLE_MS;
-      const centralRefined =
-        readiness && readiness.phase !== 'unknown'
-          ? readiness.phase === 'settled'
-          : msSinceSettle >= PHASE_CENTER_PROXY_MS;
-      this._phase = nextRefinementPhase(this._phase, {
-        moving,
-        msSinceSettle,
-        settleMs: SETTLE_MS,
-        coverageComplete,
-        centralRefined,
-      });
-      target = Math.max(floor, maxDpr * phaseDprScale(this._phase));
-      if (this._phase === 'moving' && angularSpeed > 0) {
+      // P6 — step DPR by discrete refinement phase. The tracker decides when
+      // the phase advances (from the wanted-set readiness verdict where there
+      // is one, an elapsed-time proxy where there is not); this branch only
+      // reads the resolution fraction the current phase asks for.
+      target = Math.max(floor, maxDpr * this._phases.dprScale);
+      if (phase === 'moving' && angularSpeed > 0) {
         // P3 — faster rotation pulls the moving-phase resolution toward the floor.
         const t = Math.min(1, angularSpeed / DPR_FULL_REDUCTION_ANGULAR);
         target = Math.max(floor, target + (floor - target) * t);
@@ -6327,7 +6318,7 @@ export class Viewer {
       activityUntilMs: () => this._renderGate.activityUntilMs,
       edlEnabled: () => this._edlEnabled,
       applyAdaptiveDpr: (moving, delta, nowMs, rendered) =>
-        this._applyAdaptiveDpr(moving, delta, nowMs, rendered),
+        this._updateRefinementAndDpr(moving, delta, nowMs, rendered),
       noteRendered: () => this._renderGate.noteRendered(),
       noteSkipped: () => this._renderGate.noteSkipped(),
       renderEdl: () => { this._syncActiveCamera(); this._post.render(); },

--- a/src/render/refinementPhase.ts
+++ b/src/render/refinementPhase.ts
@@ -116,6 +116,30 @@ export function phaseSelectionFactor(phase: RefinementPhase): number {
 }
 
 /**
+ * How hard the streaming scheduler pulls node ordering toward the viewed centre,
+ * per phase, in `[0, 1)`. Only `center-refine` biases: while moving and while
+ * building coverage the whole viewport matters equally, and `full-refine` is by
+ * definition the phase that stops preferring the middle.
+ *
+ * The value multiplies into the score's BOUNDED projected-size term as
+ * `1 - focusStrength * (1 - centerWeight)`, so an edge node is demoted within
+ * its own depth level and never across one: the factor lies in `(0, 1]`, which
+ * can only shrink a size term that was already `< DEPTH_WEIGHT`. Coarse-first
+ * therefore holds for every strength in `[0, 1)`.
+ */
+export const PHASE_FOCUS_STRENGTH: Readonly<Record<RefinementPhase, number>> = {
+  moving: 0,
+  coverage: 0,
+  'center-refine': 0.32,
+  'full-refine': 0,
+};
+
+/** Centre-bias strength for the given phase (see {@link PHASE_FOCUS_STRENGTH}). */
+export function phaseFocusStrength(phase: RefinementPhase): number {
+  return PHASE_FOCUS_STRENGTH[phase];
+}
+
+/**
  * Center weighting for a node's projected position (§P6). `projX/projY` are the
  * node's NDC position; `aspectWx/aspectWy` scale the axes so "center distance"
  * accounts for the viewport aspect. Returns `clamp(1 − centerDistance, 0, 1)`:

--- a/src/render/refinementPhaseState.ts
+++ b/src/render/refinementPhaseState.ts
@@ -1,0 +1,100 @@
+/**
+ * refinementPhaseState.ts
+ *
+ * The stateful half of the P6 refinement phase machine: "which phase are we in,
+ * and when did the camera park?". `refinementPhase.ts` holds the pure transition
+ * function and the weighting tables; this module holds the two mutable fields
+ * that drive it and the mapping from a readiness verdict to the machine's two
+ * boolean signals.
+ *
+ * It lives outside `Viewer` because the phase has two consumers with different
+ * lifetimes. Adaptive DPR reads it only on frames that actually render, and only
+ * when the `?adaptiveDpr` flag is on; the streaming scheduler reads it on every
+ * scheduler tick regardless. While the bookkeeping sat inside the DPR branch,
+ * disabling adaptive DPR froze the phase at `moving` forever — invisible while
+ * DPR was the only reader, wrong the moment node ordering depends on it. One
+ * tracker, advanced unconditionally, removes the coupling without introducing a
+ * second phase state to disagree with the first.
+ *
+ * Pure state, no DOM and no three.js — unit-tested in Node.
+ */
+
+import { SETTLE_MS } from './orbitFeel';
+import { nextRefinementPhase, phaseDprScale, type RefinementPhase } from './refinementPhase';
+import type { RefinementReadinessPhase } from './streaming/refinementReadiness';
+
+/** What one frame tells the tracker. */
+export interface RefinementPhaseInput {
+  /** Is the camera moving this frame? Any motion resets to `moving`. */
+  readonly moving: boolean;
+  /** The frame timestamp, in milliseconds. */
+  readonly nowMs: number;
+  /** The scheduler's wanted-set readiness verdict, or null when there is none. */
+  readonly readiness: { readonly phase: RefinementReadinessPhase } | null;
+}
+
+/** Elapsed-time proxy for "the centre is refined", used only without a verdict. */
+export const PHASE_CENTER_PROXY_MS = 250;
+
+/**
+ * Owns the live refinement phase and the park timestamp behind it.
+ *
+ * With a streaming scheduler attached, the coverage / central-refine signals
+ * come from the wanted-set readiness verdict, so full resolution is reached
+ * only when the requested nodes are resident rather than after a fixed time
+ * over a half-loaded cloud. Without a verdict — a static cloud with nothing to
+ * stream, or before the first cull — the elapsed-time proxies stand in, because
+ * there is no outstanding data for a signal to describe.
+ */
+export class RefinementPhaseTracker {
+  private _phase: RefinementPhase = 'moving';
+  /** Frame timestamp when the camera last parked; null while moving. */
+  private _settledAtMs: number | null = null;
+
+  private readonly _settleMs: number;
+  private readonly _centerProxyMs: number;
+
+  constructor(settleMs: number = SETTLE_MS, centerProxyMs: number = PHASE_CENTER_PROXY_MS) {
+    this._settleMs = settleMs;
+    this._centerProxyMs = centerProxyMs;
+  }
+
+  /** The current phase, without advancing it. */
+  get phase(): RefinementPhase {
+    return this._phase;
+  }
+
+  /**
+   * The adaptive-DPR resolution fraction for the current phase — the same
+   * `PHASE_DPR_SCALE` lookup the pure module owns, offered here so a caller
+   * that already holds the tracker does not couple to a second module for one
+   * table read.
+   */
+  get dprScale(): number {
+    return phaseDprScale(this._phase);
+  }
+
+  /** Advance one frame and return the new phase. */
+  advance(input: RefinementPhaseInput): RefinementPhase {
+    if (input.moving) this._settledAtMs = null;
+    else this._settledAtMs ??= input.nowMs;
+    const msSinceSettle =
+      input.moving || this._settledAtMs === null ? 0 : input.nowMs - this._settledAtMs;
+    const verdict =
+      input.readiness && input.readiness.phase !== 'unknown' ? input.readiness.phase : null;
+    const coverageComplete = verdict
+      ? verdict === 'settling' || verdict === 'settled'
+      : msSinceSettle >= this._settleMs;
+    const centralRefined = verdict
+      ? verdict === 'settled'
+      : msSinceSettle >= this._centerProxyMs;
+    this._phase = nextRefinementPhase(this._phase, {
+      moving: input.moving,
+      msSinceSettle,
+      settleMs: this._settleMs,
+      coverageComplete,
+      centralRefined,
+    });
+    return this._phase;
+  }
+}

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -41,6 +41,11 @@ import type { EvictionCandidate, EvictionHysteresis } from './evictionPolicy';
 import { evaluateRefinementReadiness, type SchedulerReadinessFacts } from './refinementReadiness';
 import { buildStreamingDiagnostics, type StreamingDiagnostics } from './streamingDiagnostics';
 import { computeReplaceHidden } from './replaceFrontier';
+import {
+  phaseFocusStrength,
+  phaseSelectionFactor,
+  type RefinementPhase,
+} from '../refinementPhase';
 
 /** Renderer-facing callbacks the scheduler drives. */
 export interface SchedulerCallbacks {
@@ -79,6 +84,20 @@ export interface SchedulerView {
    * keep working; when omitted, FPS pressure stays neutral.
    */
   frameTimeMs?: number;
+  /**
+   * The P6 refinement phase this tick (`refinementPhase.ts`). It sets the
+   * selection-budget multiplier and, during `center-refine`, a bounded
+   * centre bias on within-level ordering. Optional: omitted, the scheduler
+   * behaves exactly as it did before the phase wiring (full budget, no bias).
+   */
+  refinementPhase?: RefinementPhase;
+  /**
+   * Viewport size in CSS pixels. Only the aspect is used, and only to weight
+   * the centre metric; a missing or degenerate value disables centre weighting
+   * rather than guessing an aspect.
+   */
+  viewportWidthPx?: number;
+  viewportHeightPx?: number;
 }
 
 /** Live scheduler counters for diagnostics. */
@@ -635,6 +654,16 @@ export class StreamingScheduler {
   // move or the 60-tick forced rescore (~seconds of lag under exactly the
   // GPU-bound case the back-off targets).
   private _lastSigFpsFactor = -1;
+  /**
+   * Phase + viewport aspect actually used by scoring, as of the last full
+   * rescore. Both are scoring inputs now, so the stable-camera fast path must
+   * treat a phase transition (or a resize that moves the centre metric) as a
+   * signature change — a cached wanted set must never outlive a state the
+   * score depends on. `0` records "aspect did not participate this tick",
+   * which keeps a resize during a bias-free phase off the rescore path.
+   */
+  private _lastSigPhase: RefinementPhase | undefined = undefined;
+  private _lastSigFocusAspect = 0;
   private _lastSigStoreSize = -1;
   /** Last full rescore's wanted set (reused while the signature stays equal). */
   private _lastWanted: ReadonlySet<string> | null = null;
@@ -1068,6 +1097,28 @@ export class StreamingScheduler {
       store.setState(node, 'unloaded');
     }
 
+    // P6 refinement phase (optional). The phase sets how much of the point
+    // budget the wanted-set selection may spend this tick, and — during
+    // `center-refine` only — a bounded centre bias on within-level ordering.
+    // Neither touches the admission ceiling, the decode ceiling, the GPU
+    // ceiling or the cache capacity: this is arrival ORDER and how many nodes
+    // are asked for, nothing else.
+    const phase = view.refinementPhase;
+    const focusStrength = phase === undefined ? 0 : phaseFocusStrength(phase);
+    const selectionFactor = phase === undefined ? 1 : phaseSelectionFactor(phase);
+    const viewportW = view.viewportWidthPx;
+    const viewportH = view.viewportHeightPx;
+    const focusUsable =
+      focusStrength > 0 &&
+      typeof viewportW === 'number' &&
+      typeof viewportH === 'number' &&
+      Number.isFinite(viewportW) &&
+      Number.isFinite(viewportH) &&
+      viewportW > 0 &&
+      viewportH > 0;
+    // 0 = "the centre metric did not read the viewport this tick".
+    const focusAspect = focusUsable ? (viewportW as number) / (viewportH as number) : 0;
+
     // stable-camera fast path. If the scheduling
     // signature is bit-identical to last tick's AND the periodic forced
     // rescore isn't due, reuse the cached `_lastScored` and `_lastWanted`.
@@ -1087,6 +1138,8 @@ export class StreamingScheduler {
       this._pointBudget === this._lastSigBudget &&
       this._pressureDepthReduction === this._lastSigPressureReduction &&
       this._fpsBudgetFactor === this._lastSigFpsFactor &&
+      phase === this._lastSigPhase &&
+      focusAspect === this._lastSigFocusAspect &&
       // The store keeps growing while hierarchy loads (lazy COPC pages, the
       // progressive EPT walk) — a new node must invalidate the cached wanted
       // set even under a perfectly still camera, or it can't stream until the
@@ -1121,6 +1174,10 @@ export class StreamingScheduler {
             depth: node.record.depth,
             cameraPos: view.cameraPosition,
             depthCap,
+            focusStrength: focusUsable ? focusStrength : 0,
+            viewProjection: focusUsable ? view.viewProjection : undefined,
+            viewportWidthPx: viewportW,
+            viewportHeightPx: viewportH,
           });
         }
         node.score = score;
@@ -1139,9 +1196,11 @@ export class StreamingScheduler {
       // fewer nodes resident. The factor multiplies in [0.5, 1.0] and
       // composes with the memory pressure adapter (depth cap reduction)
       // that runs independently on the resident-set side.
+      // The phase factor rides here with the FPS factor: both scale only the
+      // SELECTION target, never any ceiling.
       const fpsAdjustedBudget = Math.max(
         1,
-        Math.floor(this._pointBudget * this._fpsBudgetFactor),
+        Math.floor(this._pointBudget * this._fpsBudgetFactor * selectionFactor),
       );
       // Resident stickiness (opt-in). A node already on screen keeps a small
       // bonus so score noise at the budget boundary cannot bump it out and pay
@@ -1185,6 +1244,8 @@ export class StreamingScheduler {
       this._lastSigBudget = this._pointBudget;
       this._lastSigPressureReduction = this._pressureDepthReduction;
       this._lastSigFpsFactor = this._fpsBudgetFactor;
+      this._lastSigPhase = phase;
+      this._lastSigFocusAspect = focusAspect;
       this._lastSigStoreSize = store.size;
       this._lastScored = freshScored;
       this._lastWanted = freshWanted;

--- a/src/render/streaming/streamingScore.ts
+++ b/src/render/streaming/streamingScore.ts
@@ -12,6 +12,7 @@
  * Pure — no DOM, no three.js — fully unit-tested in Node.
  */
 
+import { centerWeight } from '../refinementPhase';
 import type { Box6 } from '../../io/copc/copcTypes';
 
 /** A plane `[a, b, c, d]`; a point is inside when `a·x + b·y + c·z + d ≥ 0`. */
@@ -88,6 +89,69 @@ export function projectedSize(box: Box6, cam: readonly [number, number, number])
   return boxDiagonal(box) / Math.max(distanceToBox(box, cam), 1e-3);
 }
 
+/**
+ * How close a box lands to the centre of the view, in `[0, 1]` — 1 when the
+ * box covers the centre, falling to 0 at the viewport edge.
+ *
+ * The 8 local-space AABB corners are projected through the column-major
+ * view-projection; the NDC axis-aligned rectangle of the VALID corners is then
+ * reduced to the point nearest the origin, which is what `centerWeight` scores.
+ * Taking the nearest point of the RECTANGLE rather than the box's projected
+ * centre is what makes a large node crossing the middle of the screen rank as
+ * central even when its geometric centre is off to one side.
+ *
+ * Fails conservatively: a box straddling the camera plane, a non-finite matrix,
+ * a short matrix, or a degenerate viewport all return 1 — the neutral maximum.
+ * Near-camera geometry is exactly the case that produces a negative clip `w`,
+ * so a "no opinion" answer here must never be the low-priority one.
+ */
+export function projectedBoxCenterWeight(
+  box: Box6,
+  viewProjection: ArrayLike<number>,
+  widthPx: number,
+  heightPx: number,
+): number {
+  const m = viewProjection;
+  if (m.length < 16) return 1;
+  if (
+    !Number.isFinite(widthPx) ||
+    !Number.isFinite(heightPx) ||
+    widthPx <= 0 ||
+    heightPx <= 0
+  ) {
+    return 1;
+  }
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (let c = 0; c < 8; c++) {
+    const x = box[c & 1 ? 3 : 0];
+    const y = box[c & 2 ? 4 : 1];
+    const z = box[c & 4 ? 5 : 2];
+    const w = m[3] * x + m[7] * y + m[11] * z + m[15];
+    // A corner at or behind the camera plane makes the divide meaningless —
+    // and a box with any such corner is close enough to matter, so give up and
+    // return the neutral maximum rather than a half-projected rectangle.
+    if (!(w > 1e-9) || !Number.isFinite(w)) return 1;
+    const nx = (m[0] * x + m[4] * y + m[8] * z + m[12]) / w;
+    const ny = (m[1] * x + m[5] * y + m[9] * z + m[13]) / w;
+    if (!Number.isFinite(nx) || !Number.isFinite(ny)) return 1;
+    if (nx < minX) minX = nx;
+    if (nx > maxX) maxX = nx;
+    if (ny < minY) minY = ny;
+    if (ny > maxY) maxY = ny;
+  }
+  // Nearest point of the NDC rectangle to the screen centre.
+  const px = Math.min(Math.max(0, minX), maxX);
+  const py = Math.min(Math.max(0, minY), maxY);
+  const aspect = widthPx / heightPx;
+  if (!Number.isFinite(aspect) || aspect <= 0) return 1;
+  const aspectWx = aspect >= 1 ? aspect : 1;
+  const aspectWy = aspect >= 1 ? 1 : 1 / aspect;
+  return centerWeight(px, py, aspectWx, aspectWy);
+}
+
 /** Inputs for a node's streaming priority score. */
 export interface NodeScoreInput {
   bounds: Box6;
@@ -95,6 +159,17 @@ export interface NodeScoreInput {
   cameraPos: readonly [number, number, number];
   /** The maximum depth to load this tick — deeper nodes score 0. */
   depthCap: number;
+  /**
+   * Centre-bias strength in `[0, 1)` — see `PHASE_FOCUS_STRENGTH`. Omitted or
+   * 0 (every phase but `center-refine`, and every caller that predates the
+   * phase wiring) scores exactly as before.
+   */
+  focusStrength?: number;
+  /** Column-major view-projection, required for the centre weighting. */
+  viewProjection?: ArrayLike<number>;
+  /** Viewport size in CSS pixels — only the aspect is used. */
+  viewportWidthPx?: number;
+  viewportHeightPx?: number;
 }
 
 /**
@@ -123,6 +198,25 @@ export const SIZE_TERM_MAX = DEPTH_WEIGHT - 1;
 export const SIZE_TERM_SCALE = 1000;
 
 /**
+ * The projected size after the phase's centre bias. Any missing or unusable
+ * input (no strength, no matrix, no viewport) returns the raw size, so the
+ * legacy scoring path is bit-identical.
+ */
+function focusedProjectedSize(ps: number, input: NodeScoreInput): number {
+  const strength = input.focusStrength;
+  if (typeof strength !== 'number' || !(strength > 0) || !input.viewProjection) return ps;
+  const cw = projectedBoxCenterWeight(
+    input.bounds,
+    input.viewProjection,
+    input.viewportWidthPx ?? Number.NaN,
+    input.viewportHeightPx ?? Number.NaN,
+  );
+  const factor = 1 - Math.min(strength, 1) * (1 - cw);
+  if (!Number.isFinite(factor) || factor <= 0) return ps;
+  return ps * factor;
+}
+
+/**
  * A node's streaming priority — higher loads sooner.
  *
  * The score is `depthContribution + sizeTerm`, where:
@@ -141,7 +235,12 @@ export function nodeScore(input: NodeScoreInput): number {
   // is false, so a `score > 0` budget selector would admit the garbage node.
   // Reject it explicitly.
   if (!Number.isFinite(ps)) return 0;
-  const sizeTerm = Math.min(Math.round(ps * SIZE_TERM_SCALE), SIZE_TERM_MAX);
+  // Focus-aware ordering WITHIN a level. `focusFactor ∈ (0, 1]` because
+  // `focusStrength ∈ [0, 1)` and `centerWeight ∈ [0, 1]`, so the focused
+  // projected size is never larger than the raw one and never negative — the
+  // size term stays inside `[0, SIZE_TERM_MAX]` and coarse-first is untouched.
+  const focused = focusedProjectedSize(ps, input);
+  const sizeTerm = Math.min(Math.round(focused * SIZE_TERM_SCALE), SIZE_TERM_MAX);
   const depthContribution =
     (input.depthCap - input.depth + 1) * DEPTH_WEIGHT;
   return depthContribution + sizeTerm;

--- a/tests/focusAwareRefinement.test.ts
+++ b/tests/focusAwareRefinement.test.ts
@@ -1,0 +1,225 @@
+/**
+ * focusAwareRefinement.test.ts
+ *
+ * Focus-aware ordering WITHIN a refinement level: during `center-refine` the
+ * scheduler prefers nodes that project near the viewed centre, without ever
+ * breaking the coarse-first invariant that a shallower node outranks a deeper
+ * one. Everything under test is pure — the projection maths, the phase tables,
+ * and the phase tracker the Viewer delegates its bookkeeping to.
+ */
+
+import { readFileSync } from 'node:fs';
+import {
+  DEPTH_WEIGHT,
+  SIZE_TERM_MAX,
+  nodeScore,
+  projectedBoxCenterWeight,
+} from '../src/render/streaming/streamingScore';
+import {
+  PHASE_FOCUS_STRENGTH,
+  phaseFocusStrength,
+  phaseSelectionFactor,
+} from '../src/render/refinementPhase';
+import { RefinementPhaseTracker } from '../src/render/refinementPhaseState';
+import type { Box6 } from '../src/io/copc/copcTypes';
+
+/**
+ * A column-major view-projection that maps world XY straight to NDC XY and
+ * leaves `w = 1` — the simplest matrix that still exercises the perspective
+ * divide path.
+ */
+const FLAT = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+/** A small box centred on (cx, cy) in the FLAT frame. */
+const boxAt = (cx: number, cy: number, half = 0.02): Box6 => [
+  cx - half, cy - half, -half, cx + half, cy + half, half,
+];
+
+/** Score one node with the focus inputs the scheduler passes. */
+function score(bounds: Box6, depth: number, focusStrength: number): number {
+  return nodeScore({
+    bounds,
+    depth,
+    cameraPos: [0, 0, 5],
+    depthCap: 10,
+    focusStrength,
+    viewProjection: FLAT,
+    viewportWidthPx: 1000,
+    viewportHeightPx: 1000,
+  });
+}
+
+// --- centre weighting --------------------------------------------------------
+
+test('a box straddling the viewport centre gets the maximum centre weight', () => {
+  // Geometric centre well off to the right, but the AABB covers (0, 0).
+  const w = projectedBoxCenterWeight([-0.1, -0.9, -1, 0.9, 0.1, 1], FLAT, 1000, 1000);
+  expect(w).toBe(1);
+});
+
+test('centre weight falls off toward the edge', () => {
+  const middle = projectedBoxCenterWeight(boxAt(0, 0), FLAT, 1000, 1000);
+  const halfway = projectedBoxCenterWeight(boxAt(0.5, 0), FLAT, 1000, 1000);
+  const edge = projectedBoxCenterWeight(boxAt(0.98, 0), FLAT, 1000, 1000);
+  expect(middle).toBeGreaterThan(halfway);
+  expect(halfway).toBeGreaterThan(edge);
+  expect(edge).toBeGreaterThanOrEqual(0);
+});
+
+test('centre weight is symmetric left/right and top/bottom', () => {
+  const left = projectedBoxCenterWeight(boxAt(-0.4, 0), FLAT, 1600, 900);
+  const right = projectedBoxCenterWeight(boxAt(0.4, 0), FLAT, 1600, 900);
+  expect(left).toBeCloseTo(right, 12);
+  const up = projectedBoxCenterWeight(boxAt(0, 0.4), FLAT, 1600, 900);
+  const down = projectedBoxCenterWeight(boxAt(0, -0.4), FLAT, 1600, 900);
+  expect(up).toBeCloseTo(down, 12);
+});
+
+test('an unusable projection or viewport yields the neutral maximum weight', () => {
+  const behind = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, -1, 0, 0, 0, 0];
+  expect(projectedBoxCenterWeight(boxAt(0.9, 0.9), behind, 1000, 1000)).toBe(1);
+  const nan = FLAT.slice();
+  nan[0] = Number.NaN;
+  expect(projectedBoxCenterWeight(boxAt(0.9, 0.9), nan, 1000, 1000)).toBe(1);
+  expect(projectedBoxCenterWeight(boxAt(0.9, 0.9), FLAT, 0, 1000)).toBe(1);
+  expect(projectedBoxCenterWeight(boxAt(0.9, 0.9), FLAT, 1000, Number.NaN)).toBe(1);
+  expect(projectedBoxCenterWeight(boxAt(0.9, 0.9), FLAT.slice(0, 8), 1000, 1000)).toBe(1);
+});
+
+// --- ordering within a level -------------------------------------------------
+
+/**
+ * Two boxes at the SAME distance from the camera — so `projectedSize`, and
+ * therefore the unbiased size term, is identical — one on the centre line and
+ * one out toward the corner.
+ */
+const EDGE_Z = 5 - Math.sqrt(25 - 2 * 0.9 * 0.9);
+const CENTRE_BOX = boxAt(0, 0);
+const EDGE_BOX: Box6 = [
+  0.9 - 0.02, 0.9 - 0.02, EDGE_Z - 0.02, 0.9 + 0.02, 0.9 + 0.02, EDGE_Z + 0.02,
+];
+
+test('the two comparison boxes project to the same size', () => {
+  expect(score(CENTRE_BOX, 4, 0)).toBe(score(EDGE_BOX, 4, 0));
+});
+
+test('center-refine orders a centred node above an equal edge node', () => {
+  const f = phaseFocusStrength('center-refine');
+  expect(score(CENTRE_BOX, 4, f)).toBeGreaterThan(score(EDGE_BOX, 4, f));
+});
+
+test('coverage, moving and full-refine apply no centre bias', () => {
+  for (const phase of ['moving', 'coverage', 'full-refine'] as const) {
+    const f = phaseFocusStrength(phase);
+    expect(f).toBe(0);
+    expect(score(CENTRE_BOX, 4, f)).toBe(score(EDGE_BOX, 4, f));
+  }
+});
+
+test('a node with no phase supplied scores exactly as the legacy scorer did', () => {
+  const legacy = nodeScore({ bounds: boxAt(0.9, 0.9), depth: 4, cameraPos: [0, 0, 5], depthCap: 10 });
+  expect(score(boxAt(0.9, 0.9), 4, 0)).toBe(legacy);
+});
+
+test('coarse-first survives every focus weight in [0, 1)', () => {
+  for (let f = 0; f < 1; f += 0.01) {
+    const shallowEdge = score(boxAt(0.99, 0.99), 3, f);
+    const deepCentre = score(boxAt(0, 0), 4, f);
+    expect(shallowEdge).toBeGreaterThan(deepCentre);
+    expect(Number.isFinite(shallowEdge)).toBe(true);
+  }
+});
+
+test('the focused size term stays strictly below DEPTH_WEIGHT', () => {
+  // A box that fills the view saturates the size term; the depth contribution
+  // for depth === depthCap is exactly one DEPTH_WEIGHT, so the whole score must
+  // stay under two.
+  const huge: Box6 = [-1, -1, -1, 1, 1, 1];
+  for (const f of [0, 0.32, 0.99]) {
+    const s = nodeScore({
+      bounds: huge,
+      depth: 10,
+      cameraPos: [0, 0, 0.001],
+      depthCap: 10,
+      focusStrength: f,
+      viewProjection: FLAT,
+      viewportWidthPx: 1000,
+      viewportHeightPx: 1000,
+    });
+    expect(s - DEPTH_WEIGHT).toBeGreaterThanOrEqual(0);
+    expect(s - DEPTH_WEIGHT).toBeLessThanOrEqual(SIZE_TERM_MAX);
+    expect(s - DEPTH_WEIGHT).toBeLessThan(DEPTH_WEIGHT);
+  }
+});
+
+test('a bad projection never poisons the score', () => {
+  const s = nodeScore({
+    bounds: boxAt(0, 0),
+    depth: 4,
+    cameraPos: [0, 0, 5],
+    depthCap: 10,
+    focusStrength: 0.32,
+    viewProjection: [Number.NaN, ...FLAT.slice(1)],
+    viewportWidthPx: 1000,
+    viewportHeightPx: 1000,
+  });
+  expect(Number.isFinite(s)).toBe(true);
+  expect(s).toBeGreaterThan(0);
+});
+
+// --- phase tables ------------------------------------------------------------
+
+test('the selection budget grows monotonically across the phases', () => {
+  expect(phaseSelectionFactor('moving')).toBeLessThan(phaseSelectionFactor('coverage'));
+  expect(phaseSelectionFactor('coverage')).toBeLessThan(phaseSelectionFactor('center-refine'));
+  expect(phaseSelectionFactor('center-refine')).toBeLessThan(phaseSelectionFactor('full-refine'));
+});
+
+test('only center-refine carries a focus strength, and it is bounded', () => {
+  expect(PHASE_FOCUS_STRENGTH['center-refine']).toBeGreaterThan(0);
+  for (const v of Object.values(PHASE_FOCUS_STRENGTH)) {
+    expect(v).toBeGreaterThanOrEqual(0);
+    expect(v).toBeLessThan(1);
+  }
+});
+
+// --- phase bookkeeping is independent of the DPR decision --------------------
+
+test('the tracker advances moving → coverage → center-refine → full-refine', () => {
+  const t = new RefinementPhaseTracker();
+  expect(t.phase).toBe('moving');
+  expect(t.advance({ moving: true, nowMs: 0, readiness: null })).toBe('moving');
+  expect(t.advance({ moving: false, nowMs: 10, readiness: null })).toBe('coverage');
+  expect(t.advance({ moving: false, nowMs: 10_000, readiness: null })).toBe('full-refine');
+  // Any motion drops straight back to coarse.
+  expect(t.advance({ moving: true, nowMs: 10_100, readiness: null })).toBe('moving');
+});
+
+test('the tracker prefers the readiness verdict over the elapsed-time proxy', () => {
+  const t = new RefinementPhaseTracker();
+  t.advance({ moving: false, nowMs: 0, readiness: { phase: 'loading' } });
+  // Far past both proxy windows, but the verdict says nothing is resident yet.
+  expect(t.advance({ moving: false, nowMs: 10_000, readiness: { phase: 'loading' } })).toBe(
+    'coverage',
+  );
+  expect(t.advance({ moving: false, nowMs: 10_016, readiness: { phase: 'settling' } })).toBe(
+    'center-refine',
+  );
+  expect(t.advance({ moving: false, nowMs: 10_032, readiness: { phase: 'settled' } })).toBe(
+    'full-refine',
+  );
+});
+
+test('Viewer advances the phase before the adaptive-DPR early return', () => {
+  // §4 regression guard: the phase used to be advanced inside the adaptive-DPR
+  // branch, so with `?adaptiveDpr=0` it stayed 'moving' forever. Harmless while
+  // nothing else read it; wrong now that the scheduler does.
+  const src = readFileSync(new URL('../src/render/Viewer.ts', import.meta.url), 'utf8');
+  const advance = src.indexOf('this._phases.advance(');
+  const dprGuard = src.indexOf('if (!this._adaptiveDpr');
+  expect(advance).toBeGreaterThan(-1);
+  expect(dprGuard).toBeGreaterThan(-1);
+  expect(advance).toBeLessThan(dprGuard);
+  // And exactly one phase state, read by both consumers.
+  expect(src).not.toMatch(/schedulerPhase|dprPhase/);
+});

--- a/tests/streamingScheduler.test.ts
+++ b/tests/streamingScheduler.test.ts
@@ -1209,3 +1209,105 @@ test('a cached chunk is handed to the decoder as a copy, never the cache-held bu
   expect(fresh.size).toBeGreaterThan(0);
   for (const chunk of seen) expect(fresh.has(chunk)).toBe(false);
 });
+
+// --- focus-aware refinement (P6 phase wiring) --------------------------------
+
+test('the phase selection factor shrinks the wanted set, coarse-first order intact', async () => {
+  const cloud = await openCloud();
+  const mk = () =>
+    new StreamingScheduler(
+      cloud,
+      fakeDecoder,
+      { onNodeReady: () => {}, onNodeEvicted: () => {} },
+      { ...streamingBudgets('balanced', false), pointBudget: 4_000 },
+      { now: () => 0 },
+    );
+  const counts: number[] = [];
+  for (const phase of ['moving', 'coverage', 'center-refine', 'full-refine'] as const) {
+    const s = mk();
+    s.update({
+      viewProjection: WIDE,
+      cameraPosition: [0, 0, 0],
+      refinementPhase: phase,
+      viewportWidthPx: 1000,
+      viewportHeightPx: 800,
+    });
+    counts.push(s.readinessFacts().wantedCount);
+  }
+  // Strictly ordered by the existing PHASE_SELECTION_FACTOR table: a coarser
+  // phase asks for fewer nodes than a finer one.
+  for (let i = 1; i < counts.length; i++) {
+    expect(counts[i]).toBeGreaterThanOrEqual(counts[i - 1]);
+  }
+  // And the table is actually biting, not just tying everywhere: the coarsest
+  // phase asks for strictly fewer nodes than the finest.
+  expect(counts[0]).toBeLessThan(counts[3]);
+  // Omitting the phase behaves exactly like full-refine (legacy callers).
+  const legacy = mk();
+  legacy.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+  expect(legacy.readinessFacts().wantedCount).toBe(counts[3]);
+});
+
+test('a phase change alone forces a full rescore', async () => {
+  let clock = 0;
+  const cloud = await openCloud();
+  const scheduler = new StreamingScheduler(
+    cloud,
+    fakeDecoder,
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    streamingBudgets('balanced', false),
+    { now: () => clock },
+  );
+  const view = {
+    viewProjection: WIDE,
+    cameraPosition: [0, 0, 0] as [number, number, number],
+    viewportWidthPx: 1000,
+    viewportHeightPx: 800,
+  };
+  scheduler.update({ ...view, refinementPhase: 'coverage' });
+  await drain(scheduler);
+  const baseline = scheduler.stats().fullRescoreCount;
+
+  clock += 16;
+  scheduler.update({ ...view, refinementPhase: 'coverage' });
+  expect(scheduler.stats().fullRescoreCount).toBe(baseline);
+
+  clock += 16;
+  scheduler.update({ ...view, refinementPhase: 'center-refine' });
+  expect(scheduler.stats().fullRescoreCount).toBe(baseline + 1);
+});
+
+test('a viewport aspect change forces a rescore only where it changes weighting', async () => {
+  let clock = 0;
+  const cloud = await openCloud();
+  const scheduler = new StreamingScheduler(
+    cloud,
+    fakeDecoder,
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    streamingBudgets('balanced', false),
+    { now: () => clock },
+  );
+  const base = { viewProjection: WIDE, cameraPosition: [0, 0, 0] as [number, number, number] };
+  scheduler.update({ ...base, refinementPhase: 'center-refine', viewportWidthPx: 1000, viewportHeightPx: 800 });
+  await drain(scheduler);
+  let n = scheduler.stats().fullRescoreCount;
+
+  // Same aspect, different pixel counts — weighting is unchanged, no rescore.
+  clock += 16;
+  scheduler.update({ ...base, refinementPhase: 'center-refine', viewportWidthPx: 500, viewportHeightPx: 400 });
+  expect(scheduler.stats().fullRescoreCount).toBe(n);
+
+  // A real aspect change alters the centre metric — rescore.
+  clock += 16;
+  scheduler.update({ ...base, refinementPhase: 'center-refine', viewportWidthPx: 500, viewportHeightPx: 900 });
+  expect(scheduler.stats().fullRescoreCount).toBe(n + 1);
+  n = scheduler.stats().fullRescoreCount;
+
+  // In a phase with no focus weighting, aspect is not a scoring input.
+  clock += 16;
+  scheduler.update({ ...base, refinementPhase: 'coverage', viewportWidthPx: 500, viewportHeightPx: 900 });
+  n = scheduler.stats().fullRescoreCount;
+  clock += 16;
+  scheduler.update({ ...base, refinementPhase: 'coverage', viewportWidthPx: 1600, viewportHeightPx: 400 });
+  expect(scheduler.stats().fullRescoreCount).toBe(n);
+});


### PR DESCRIPTION
`phaseSelectionFactor` and `centerWeight` existed in `refinementPhase.ts` with no consumer. The scheduler now reads them, so ordering within a refinement level favours what the user is looking at during `center-refine`.

Selection budget is `pointBudget × fpsBudgetFactor × phaseSelectionFactor(phase)`, applied to the wanted-set target only; admission, decompressor, GPU and cache ceilings are untouched. Priority uses `focusFactor = 1 - focusStrength × (1 - centerWeight)` folded into the existing bounded size term, so `focusedSizeTerm < DEPTH_WEIGHT` still holds and a shallower node always outranks a deeper one. New `projectedBoxCenterWeight` projects the node's eight AABB corners and returns neutral weight when no stable NDC rectangle exists.

Refinement-phase bookkeeping moves to `RefinementPhaseTracker`, so the phase advances whether or not adaptive DPR runs. Phase and focus aspect join the fast-path signature.
