### PR TITLE
feat(render): compensate point size for coarse streaming nodes while a view refines

### DIFF
--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -58,7 +58,6 @@ import {
   length,
   smoothstep,
   step,
-  positionView,
   positionGeometry,
   perspectiveDepthToViewZ,
 } from 'three/tsl';
@@ -114,7 +113,7 @@ import type { RefinementReadiness } from './streaming/refinementReadiness';
 import { readDevFlags } from '../perf/devFlags';
 import { POINT_STYLE_DEFAULTS } from './pointStyle';
 import type { PointSizeMode } from './pointStyle';
-import { ensureDensitySizes, pointSizeBaseNode } from './densityPointSize';
+import { buildAdaptiveSizeNode, CoarseLodSizeNodes, ensureDensitySizes, pointSizeBaseNode } from './densityPointSize';
 import {
   splatRadiusMultiplier,
   splatForcesAlphaToCoverage,
@@ -677,30 +676,6 @@ function buildEdlOutputNode(
 }
 
 /**
- * Build the adaptive point-size node: a point's pixel size is `base × ref /
- * eyeDistance`, clamped to `[minSizePx, base × maxSizeFactor]`. Mirrors
- * `adaptivePointSize` in `pointStyle.ts`. `positionView` is the point's
- * instance centre in view space, so `-z` is its eye-space distance.
- */
-function buildAdaptiveSizeNode(
-  base: TslNode,
-  attnRef: TslNode,
-  orthoDist: TslNode,
-  orthoFlag: TslNode,
-): TslNode {
-  // Perspective: divide by each point's own eye distance so far points shrink.
-  // Orthographic: there is no perspective divide, so every point takes the
-  // SAME size — divide by the camera's distance to the target (a uniform)
-  // instead, which makes points scale with zoom but not with depth. `orthoFlag`
-  // is exactly 0 or 1, so `mix` selects one divisor with no blending.
-  const eyeDist: TslNode = max((positionView as TslNode).z.negate(), float(1e-4));
-  const divisor: TslNode = mix(eyeDist, orthoDist, orthoFlag);
-  const attenuated: TslNode = base.mul(attnRef).div(divisor);
-  const maxSize: TslNode = base.mul(POINT_STYLE_DEFAULTS.maxSizeFactor);
-  return attenuated.clamp(float(POINT_STYLE_DEFAULTS.minSizePx), maxSize);
-}
-
-/**
  * Build the circular point-mask opacity node: `positionGeometry.xy` is the
  * sprite-quad coordinate in [-0.5, 0.5]², so the point renders as a round dot
  * with a soft, antialiased rim instead of a hard square.
@@ -981,6 +956,17 @@ export class Viewer {
     this._attnRef,
     this._orthoSizeDist,
     this._orthoSizeFlag,
+  );
+  /**
+   * Coarse-LOD display compensation for streamed nodes (`streamingLodSize.ts`):
+   * one shared phase-gain uniform plus a per-streaming-material relative-
+   * resolution uniform. Static clouds are never registered, so their size graph
+   * is byte-identical to the pre-compensation one.
+   */
+  private readonly _lodSize = new CoarseLodSizeNodes(
+    uniform,
+    this._pointSizeUniform,
+    float(POINT_STYLE_DEFAULTS.minSizePx),
   );
 
   // ── Class visibility (GPU mask) ───────────────────────────────────────────
@@ -1863,6 +1849,8 @@ export class Viewer {
     this._scene.add(mesh);
     this._streamingMeshes.add(mesh);
     this._streamingPickData.set(mesh, { decoded, depth, key });
+    const lodMaterial = mesh.material as THREE.PointsNodeMaterial;
+    if (this._lodSize.register(lodMaterial)) this._applySizeMode(lodMaterial);
   }
 
   /**
@@ -1890,6 +1878,7 @@ export class Viewer {
     this._scene.remove(mesh);
     this._streamingMeshes.delete(mesh);
     this._streamingPickData.delete(mesh);
+    this._lodSize.forget(mesh.material as THREE.PointsNodeMaterial);
     mesh.geometry.dispose();
     (mesh.material as THREE.Material).dispose();
   }
@@ -5132,7 +5121,11 @@ export class Viewer {
     // A streaming node mid-dissolve folds a per-point opaque dither (same
     // size×mask shape as the filters); dropped again the moment it settles.
     const foldFade = this._materialsWithFade.has(material);
-    if (!foldClass && !foldElev && !foldInten && !foldFade) {
+    // A streamed node folds its coarse-LOD display multiplier; never in `fixed`
+    // mode, and never on a static cloud (which is not registered at all), so the
+    // no-fold fast path below still resolves to exactly `base` for static clouds.
+    const foldLod = this._lodSize.has(material, this._pointSizeMode);
+    if (!foldClass && !foldElev && !foldInten && !foldFade && !foldLod) {
       material.sizeNode = base as typeof material.sizeNode;
       return;
     }
@@ -5140,6 +5133,7 @@ export class Viewer {
     // `materialPointSize` (the node form of `material.size`) so the pixel size is
     // preserved while the mask(s) multiply it, then fold each active multiplier.
     let node: TslNode = base ?? materialPointSize;
+    if (foldLod) node = this._lodSize.apply(node, material);
     if (foldElev) node = node.mul(this._elevGpu.maskMultiplier(material));
     if (foldClass) node = node.mul(this._classMaskMultiplier());
     if (foldInten) node = node.mul(this._intenMaskMultiplier());
@@ -6317,8 +6311,14 @@ export class Viewer {
       isTweening: () => this._nav.isTweening,
       activityUntilMs: () => this._renderGate.activityUntilMs,
       edlEnabled: () => this._edlEnabled,
-      applyAdaptiveDpr: (moving, delta, nowMs, rendered) =>
-        this._updateRefinementAndDpr(moving, delta, nowMs, rendered),
+      applyAdaptiveDpr: (moving, delta, nowMs, rendered) => {
+        this._updateRefinementAndDpr(moving, delta, nowMs, rendered);
+        // Shared coarse-LOD gain follows the live phase — a uniform write, so
+        // no material rebuilds. Reads the same tracker the scheduler does
+        // (advances with DPR off); flag off means `full-refine`, the identity.
+        const p = this._refinementPhasesEnabled ? this._phases.phase : 'full-refine';
+        this._lodSize.setPhase(p);
+      },
       noteRendered: () => this._renderGate.noteRendered(),
       noteSkipped: () => this._renderGate.noteSkipped(),
       renderEdl: () => { this._syncActiveCamera(); this._post.render(); },

--- a/src/render/densityPointSize.ts
+++ b/src/render/densityPointSize.ts
@@ -13,9 +13,13 @@
  * measurement.
  */
 import * as THREE from 'three/webgpu';
-import { attribute } from 'three/tsl';
+import { attribute, float, max, mix, positionView } from 'three/tsl';
 import { localDensitySizes, autoDensitySizeParams } from './localDensitySize';
-import type { PointSizeMode } from './pointStyle';
+import { POINT_STYLE_DEFAULTS, type PointSizeMode } from './pointStyle';
+
+// The coarse-LOD display fold is part of the same size-graph wiring seam, so it
+// reaches the Viewer through this module rather than as a second direct import.
+export { CoarseLodSizeNodes } from './streamingLodSize';
 
 // Broad TSL node type, matching how Viewer.ts bridges the three/tsl graph.
 type TslNode = any; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -68,4 +72,28 @@ export function pointSizeBaseNode(
   const density = mode === 'density' && material.userData?.[DENSITY_SIZE_FLAG] === true;
   if (density) return adaptiveNode.mul(attribute('aSize'));
   return mode === 'fixed' ? null : adaptiveNode;
+}
+
+/**
+ * Build the adaptive point-size node: a point's pixel size is `base × ref /
+ * eyeDistance`, clamped to `[minSizePx, base × maxSizeFactor]`. Mirrors
+ * `adaptivePointSize` in `pointStyle.ts`. `positionView` is the point's
+ * instance centre in view space, so `-z` is its eye-space distance.
+ */
+export function buildAdaptiveSizeNode(
+  base: TslNode,
+  attnRef: TslNode,
+  orthoDist: TslNode,
+  orthoFlag: TslNode,
+): TslNode {
+  // Perspective: divide by each point's own eye distance so far points shrink.
+  // Orthographic: there is no perspective divide, so every point takes the
+  // SAME size — divide by the camera's distance to the target (a uniform)
+  // instead, which makes points scale with zoom but not with depth. `orthoFlag`
+  // is exactly 0 or 1, so `mix` selects one divisor with no blending.
+  const eyeDist: TslNode = max((positionView as TslNode).z.negate(), float(1e-4));
+  const divisor: TslNode = mix(eyeDist, orthoDist, orthoFlag);
+  const attenuated: TslNode = base.mul(attnRef).div(divisor);
+  const maxSize: TslNode = base.mul(POINT_STYLE_DEFAULTS.maxSizeFactor);
+  return attenuated.clamp(float(POINT_STYLE_DEFAULTS.minSizePx), maxSize);
 }

--- a/src/render/streaming/StreamingRenderer.ts
+++ b/src/render/streaming/StreamingRenderer.ts
@@ -30,6 +30,7 @@ import { writeFloatColorsInto } from '../colorEncode';
 import { computeElevationRange, computeScalarRange } from '../elevationRange';
 import type { StreamingColorRanges } from './streamingColors';
 import type { RgbAppearance } from '../rgbAppearance';
+import { markNodeResolution } from '../streamingLodSize';
 
 /**
  * Node dissolve tunables. A freshly resident node materialises over `FADE_MS`
@@ -193,6 +194,16 @@ export class StreamingRenderer {
   >();
   /** Pending requestAnimationFrame handle for the next fade tick, if any. */
   private _fadeRafHandle: number | null = null;
+  /** This source's octree — read once, lazily, for the root reference below. */
+  private readonly _octree: StreamingSource['octree'];
+  /**
+   * The reference (root) node resolution for THIS source, resolved once and
+   * cached. Node resolution means different things per format, so it is only
+   * ever used as the denominator of a same-source ratio — never compared with
+   * another source's. `0` means the hierarchy could not state one, which the
+   * ratio reads as "no display compensation".
+   */
+  private _rootResolution: number | null = null;
 
   constructor(
     host: StreamingRendererHost,
@@ -204,6 +215,7 @@ export class StreamingRenderer {
     this._mode = mode;
     this._fadeIn = options.fadeIn ?? false;
     this._now = options.now ?? nowMs;
+    this._octree = cloud.octree;
     // Elevation range from the TIGHT data bounds, not the octree cube. A COPC
     // cube barely over-reports, but an EPT cube is cubic around a thin terrain
     // slab, so its Z can be tens of thousands of metres tall while the data
@@ -378,6 +390,12 @@ export class StreamingRenderer {
       decoded.classification ?? null,
       decoded.intensity ?? null,
     );
+    // Coarse-LOD display compensation: record this node's resolution and its
+    // source's root reference on the material, for the size-graph fold the
+    // Viewer applies. Display only — no decoded value is touched.
+    const lodMaterial = handle.material as unknown as { userData?: Record<string, unknown> };
+    lodMaterial.userData ??= {};
+    markNodeResolution(lodMaterial.userData, node.record.spacing, this._rootReferenceResolution());
     this._host.addStreamingMesh(handle.mesh, decoded, node.record.key.depth, node.record.id);
     // A node whose replace frontier said "withheld" before its mesh existed is
     // hidden on creation, so it does not flash for the frame before the next
@@ -393,6 +411,27 @@ export class StreamingRenderer {
     // fallback covers a no-rAF environment). A settled node keeps the plain
     // graph — the dither fold is dropped the moment it finishes.
     if (this._fadeIn) this._startFade(handle.mesh);
+  }
+
+  /**
+   * The root reference resolution for this source: the resolution of the
+   * shallowest node the hierarchy knows. Resolved ONCE per source and cached —
+   * never re-scanned, and never read per frame. `0` when the hierarchy states
+   * nothing usable, which disables compensation for this source.
+   */
+  private _rootReferenceResolution(): number {
+    if (this._rootResolution !== null) return this._rootResolution;
+    let bestDepth = Number.POSITIVE_INFINITY;
+    let resolution = 0;
+    for (const node of this._octree?.nodes?.() ?? []) {
+      const depth = node.record.depth;
+      const spacing = node.record.spacing;
+      if (depth >= bestDepth || !Number.isFinite(spacing) || spacing <= 0) continue;
+      bestDepth = depth;
+      resolution = spacing;
+    }
+    this._rootResolution = resolution;
+    return resolution;
   }
 
   /**

--- a/src/render/streamingLodSize.ts
+++ b/src/render/streamingLodSize.ts
@@ -1,0 +1,206 @@
+/**
+ * streamingLodSize.ts — coarse-LOD display compensation for streamed nodes.
+ *
+ * While a view is still refining, the resident streamed nodes are the coarse
+ * ones: their points sit further apart on screen, so the surface reads as
+ * speckle rather than as a surface. This module makes those coarse points
+ * slightly larger *while the view is coarse*, and fades that back to exactly
+ * the settled sizing as refinement completes.
+ *
+ * It is a DISPLAY aid and nothing else. It never touches decoded values, never
+ * feeds a measurement, an export or a terrain product, and the fully refined
+ * view converges to a scale of exactly 1 — the same sprite size the renderer
+ * produced before this module existed.
+ *
+ * Two halves:
+ *   • pure maths ({@link relativeNodeResolution}, {@link coarseLodScale}),
+ *     unit-tested in Node with no three.js import;
+ *   • {@link CoarseLodSizeNodes}, the uniform bookkeeping the Viewer folds into
+ *     its existing size graph. The graph SHAPE is constant, so a phase change
+ *     writes a uniform value and rebuilds nothing.
+ */
+
+import type { RefinementPhase } from './refinementPhase';
+import type { PointSizeMode } from './pointStyle';
+import { POINT_STYLE_DEFAULTS, maxPointSize } from './pointStyle';
+
+/** The largest multiplier a fully coarse node may take while a view moves. */
+export const MAX_LOD_SCALE = 1.6;
+
+/**
+ * How much of {@link MAX_LOD_SCALE} each refinement phase is allowed to use.
+ * `full-refine` is 0 by construction: a settled view renders at exactly the
+ * sizing it did before this module existed.
+ */
+export const PHASE_LOD_GAIN: Readonly<Record<RefinementPhase, number>> = {
+  moving: 1,
+  coverage: 1,
+  'center-refine': 0.5,
+  'full-refine': 0,
+};
+
+/** userData keys carrying a streamed node's resolution and its source's root. */
+export const NODE_RESOLUTION_KEY = 'olvNodeResolution';
+export const ROOT_RESOLUTION_KEY = 'olvRootResolution';
+
+/**
+ * A node's resolution as a fraction of its own source's root resolution, in
+ * `[0, 1]` — 1 at the root (coarsest), approaching 0 as nodes refine.
+ *
+ * Deliberately RELATIVE. Node resolution means different things per format
+ * (COPC/EPT point spacing, a 3D Tiles geometric error, an OLV tile edge), so an
+ * absolute value is not comparable across sources and is never compared here.
+ * A missing, non-finite or non-positive value on either side yields 0 — no
+ * compensation — rather than a guess.
+ */
+export function relativeNodeResolution(nodeResolution: number, rootResolution: number): number {
+  if (!Number.isFinite(nodeResolution) || nodeResolution <= 0) return 0;
+  if (!Number.isFinite(rootResolution) || rootResolution <= 0) return 0;
+  const ratio = nodeResolution / rootResolution;
+  if (!Number.isFinite(ratio) || ratio <= 0) return 0;
+  return Math.min(1, ratio);
+}
+
+/** The gain for a phase; an unknown phase contributes nothing. */
+export function phaseLodGain(phase: RefinementPhase): number {
+  return PHASE_LOD_GAIN[phase] ?? 0;
+}
+
+/**
+ * The display multiplier for one node:
+ *
+ *   `1 + phaseGain × (MAX_LOD_SCALE − 1) × relativeResolution`
+ *
+ * bounded to `[1, MAX_LOD_SCALE]`. `fixed` mode returns exactly 1: a fixed
+ * sprite size is an explicit user request and is never rescaled. The GPU graph
+ * in {@link CoarseLodSizeNodes.apply} mirrors this expression exactly.
+ */
+export function coarseLodScale(
+  relativeResolution: number,
+  phase: RefinementPhase,
+  mode: PointSizeMode,
+): number {
+  if (mode === 'fixed') return 1;
+  const rel = relativeNodeResolution(relativeResolution, 1);
+  const scale = 1 + phaseLodGain(phase) * (MAX_LOD_SCALE - 1) * rel;
+  if (!Number.isFinite(scale)) return 1;
+  return Math.min(MAX_LOD_SCALE, Math.max(1, scale));
+}
+
+/**
+ * The upper size clamp once compensation has multiplied in. The adaptive node
+ * is already clamped to `base × maxSizeFactor`; multiplying after that clamp
+ * can exceed the visual limit, so the compensated graph re-clamps to this.
+ */
+export function maxCompensatedPointSize(baseSizePx: number, maxSizeFactor: number): number {
+  return maxPointSize(baseSizePx, maxSizeFactor) * MAX_LOD_SCALE;
+}
+
+/** The factor the compensated clamp applies to the live base-size uniform. */
+export const MAX_COMPENSATED_SIZE_FACTOR = POINT_STYLE_DEFAULTS.maxSizeFactor * MAX_LOD_SCALE;
+
+/** Record a node's resolution and its source root's on a material's userData. */
+export function markNodeResolution(
+  userData: Record<string, unknown>,
+  nodeResolution: number,
+  rootResolution: number,
+): void {
+  userData[NODE_RESOLUTION_KEY] = nodeResolution;
+  userData[ROOT_RESOLUTION_KEY] = rootResolution;
+}
+
+/** A live scalar uniform — structurally what `three/tsl`'s `uniform()` returns. */
+interface UniformLike {
+  value: number;
+}
+
+/** Broad TSL node type, matching how the render layer bridges the graph. */
+type SizeNode = any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+/** The material surface this bookkeeping needs — identity plus its userData. */
+interface LodMaterial {
+  userData?: Record<string, unknown>;
+}
+
+/**
+ * Uniform bookkeeping for the compensation fold.
+ *
+ * One SHARED phase-gain uniform, plus one relative-resolution uniform per
+ * streaming material (a WeakMap keyed by material, the same ownership model the
+ * dissolve uniforms use). Only registered materials fold anything in, so a
+ * static cloud's size graph is untouched.
+ *
+ * `uniform` and the size nodes are injected rather than imported so the whole
+ * class is testable in Node without pulling in three.js.
+ */
+export class CoarseLodSizeNodes {
+  private readonly _uniform: (value: number) => UniformLike;
+  private readonly _gain: UniformLike;
+  private readonly _baseSize: SizeNode;
+  private readonly _minSize: SizeNode;
+  private readonly _rel = new WeakMap<LodMaterial, UniformLike>();
+
+  constructor(uniform: (value: number) => UniformLike, baseSize: SizeNode, minSize: SizeNode) {
+    this._uniform = uniform;
+    this._gain = uniform(PHASE_LOD_GAIN['full-refine']);
+    this._baseSize = baseSize;
+    this._minSize = minSize;
+  }
+
+  /**
+   * Point the shared gain uniform at a refinement phase. A value write only —
+   * the graph shape does not depend on the phase, so no material is rebuilt.
+   */
+  setPhase(phase: RefinementPhase): void {
+    this._gain.value = phaseLodGain(phase);
+  }
+
+  /** The gain currently driving every registered material. */
+  get phaseGain(): number {
+    return this._gain.value;
+  }
+
+  /**
+   * Register a streaming material from the resolutions its builder recorded.
+   * Returns true when the material was not registered before — the caller then
+   * re-runs its size-mode application so the fold enters the graph. A material
+   * whose resolutions are unusable registers at 0, which is the identity scale.
+   */
+  register(material: LodMaterial): boolean {
+    const data = material.userData ?? {};
+    const rel = relativeNodeResolution(
+      Number(data[NODE_RESOLUTION_KEY]),
+      Number(data[ROOT_RESOLUTION_KEY]),
+    );
+    const existing = this._rel.get(material);
+    if (existing) {
+      existing.value = rel;
+      return false;
+    }
+    this._rel.set(material, this._uniform(rel));
+    return true;
+  }
+
+  /** Whether this material folds compensation under the given size mode. */
+  has(material: LodMaterial, mode: PointSizeMode): boolean {
+    return mode !== 'fixed' && this._rel.has(material);
+  }
+
+  /** Drop a material's uniform — called when its streaming mesh is removed. */
+  forget(material: LodMaterial): void {
+    this._rel.delete(material);
+  }
+
+  /**
+   * Fold the multiplier into a resolved size node and re-clamp the product.
+   * Mirrors {@link coarseLodScale}: `size × (1 + gain × (MAX − 1) × rel)`,
+   * bounded to `[minSizePx, base × maxSizeFactor × MAX_LOD_SCALE]` so a
+   * malformed ratio can never produce a giant screen quad.
+   */
+  apply(node: SizeNode, material: LodMaterial): SizeNode {
+    const rel = this._rel.get(material);
+    if (!rel) return node;
+    const compensated = node.add(node.mul(this._gain).mul(rel).mul(MAX_LOD_SCALE - 1));
+    return compensated.clamp(this._minSize, this._baseSize.mul(MAX_COMPENSATED_SIZE_FACTOR));
+  }
+}

--- a/tests/coarseLodNodeWiring.test.ts
+++ b/tests/coarseLodNodeWiring.test.ts
@@ -1,0 +1,152 @@
+/**
+ * coarseLodNodeWiring.test.ts
+ *
+ * The renderer half of coarse-LOD display compensation: every node mesh the
+ * streaming renderer builds carries its own resolution and its SOURCE's root
+ * reference, so the Viewer's size graph can fold a same-source ratio. The root
+ * reference is resolved once and never re-scanned.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { StreamingRenderer } from '../src/render/streaming/StreamingRenderer';
+import {
+  NODE_RESOLUTION_KEY,
+  ROOT_RESOLUTION_KEY,
+  coarseLodScale,
+  relativeNodeResolution,
+} from '../src/render/streamingLodSize';
+import type { Viewer, PointMeshHandle } from '../src/render/Viewer';
+import type { StreamingSource } from '../src/render/streaming/StreamingSource';
+import type { StreamingNode } from '../src/render/streaming/StreamingNode';
+import type { DecodedChunk } from '../src/io/copc/copcChunkDecode';
+
+interface FakeMaterial {
+  id: number;
+  userData?: Record<string, unknown>;
+}
+
+function makeHost(): { viewer: Viewer; materials: FakeMaterial[] } {
+  const materials: FakeMaterial[] = [];
+  let seq = 0;
+  const viewer = {
+    buildPointMesh(_p: Float32Array, colorsU8: Uint8Array): PointMeshHandle {
+      seq++;
+      const material: FakeMaterial = { id: seq };
+      materials.push(material);
+      return {
+        mesh: { id: seq, material } as unknown as PointMeshHandle['mesh'],
+        material: material as unknown as PointMeshHandle['material'],
+        colorAttr: {
+          array: new Float32Array(colorsU8.length),
+          needsUpdate: false,
+        } as unknown as PointMeshHandle['colorAttr'],
+        classAttr: null,
+      };
+    },
+    addStreamingMesh(): void {},
+    removeStreamingMesh(): void {},
+    beginNodeDissolve(_m: unknown, start: number): number {
+      return start;
+    },
+    setNodeDissolveProgress(): void {},
+    endNodeDissolve(): void {},
+  };
+  return { viewer: viewer as unknown as Viewer, materials };
+}
+
+function makeNode(id: string, depth: number, spacing: number): StreamingNode {
+  return {
+    record: { id, depth, spacing, key: { depth, x: 0, y: 0, z: 0 } },
+  } as unknown as StreamingNode;
+}
+
+function makeSource(nodes: StreamingNode[]): {
+  source: StreamingSource;
+  scans: () => number;
+} {
+  let scans = 0;
+  const source = {
+    dataBounds: () => [0, 0, 0, 10, 10, 10] as const,
+    octree: {
+      nodes: () => {
+        scans++;
+        return nodes;
+      },
+    },
+  } as unknown as StreamingSource;
+  return { source, scans: () => scans };
+}
+
+function makeChunk(): DecodedChunk {
+  const n = 4;
+  return {
+    pointCount: n,
+    positions: new Float32Array(n * 3),
+    intensity: new Uint16Array(n),
+    classification: new Uint8Array(n),
+    returnNumber: new Uint8Array(n),
+    returnCount: new Uint8Array(n),
+    gpsTime: new Float64Array(n),
+  } as DecodedChunk;
+}
+
+describe('streamed node resolution wiring', () => {
+  test('each node records its own resolution against the source root', () => {
+    const root = makeNode('R', 0, 4);
+    const child = makeNode('C', 2, 1);
+    const { source } = makeSource([root, child]);
+    const { viewer, materials } = makeHost();
+    const renderer = new StreamingRenderer(viewer, source, 'rgb');
+
+    renderer.onNodeReady(root, makeChunk());
+    renderer.onNodeReady(child, makeChunk());
+
+    expect(materials[0].userData?.[NODE_RESOLUTION_KEY]).toBe(4);
+    expect(materials[0].userData?.[ROOT_RESOLUTION_KEY]).toBe(4);
+    expect(materials[1].userData?.[NODE_RESOLUTION_KEY]).toBe(1);
+    expect(materials[1].userData?.[ROOT_RESOLUTION_KEY]).toBe(4);
+
+    const relRoot = relativeNodeResolution(4, 4);
+    const relChild = relativeNodeResolution(1, 4);
+    expect(coarseLodScale(relChild, 'moving', 'adaptive')).toBeLessThan(
+      coarseLodScale(relRoot, 'moving', 'adaptive'),
+    );
+  });
+
+  test('the root reference is resolved once, never re-scanned per node', () => {
+    const nodes = [makeNode('R', 0, 8), makeNode('C', 1, 4), makeNode('D', 2, 2)];
+    const { source, scans } = makeSource(nodes);
+    const { viewer } = makeHost();
+    const renderer = new StreamingRenderer(viewer, source, 'rgb');
+    for (const n of nodes) renderer.onNodeReady(n, makeChunk());
+    expect(scans()).toBe(1);
+  });
+
+  test('a hierarchy that states no usable resolution disables compensation', () => {
+    const bad = makeNode('R', 0, Number.NaN);
+    const { source } = makeSource([bad]);
+    const { viewer, materials } = makeHost();
+    const renderer = new StreamingRenderer(viewer, source, 'rgb');
+    renderer.onNodeReady(bad, makeChunk());
+    const rel = relativeNodeResolution(
+      Number(materials[0].userData?.[NODE_RESOLUTION_KEY]),
+      Number(materials[0].userData?.[ROOT_RESOLUTION_KEY]),
+    );
+    expect(rel).toBe(0);
+    expect(coarseLodScale(rel, 'moving', 'adaptive')).toBe(1);
+  });
+
+  test('a node arriving while fully refined takes the identity gain', () => {
+    const root = makeNode('R', 0, 4);
+    const { source } = makeSource([root]);
+    const { viewer, materials } = makeHost();
+    const renderer = new StreamingRenderer(viewer, source, 'rgb');
+    renderer.onNodeReady(root, makeChunk());
+    const rel = relativeNodeResolution(
+      Number(materials[0].userData?.[NODE_RESOLUTION_KEY]),
+      Number(materials[0].userData?.[ROOT_RESOLUTION_KEY]),
+    );
+    expect(rel).toBe(1);
+    expect(coarseLodScale(rel, 'full-refine', 'adaptive')).toBe(1);
+  });
+});

--- a/tests/coarseLodSize.test.ts
+++ b/tests/coarseLodSize.test.ts
@@ -1,0 +1,231 @@
+/**
+ * coarseLodSize.test.ts
+ *
+ * The pure maths of coarse-LOD display compensation, plus the uniform
+ * bookkeeping that folds it into the size graph. Both halves are exercised in
+ * Node — the class takes its `uniform` factory and size nodes by injection, so
+ * the fold can be observed without a GPU.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  CoarseLodSizeNodes,
+  MAX_COMPENSATED_SIZE_FACTOR,
+  MAX_LOD_SCALE,
+  PHASE_LOD_GAIN,
+  coarseLodScale,
+  markNodeResolution,
+  maxCompensatedPointSize,
+  phaseLodGain,
+  relativeNodeResolution,
+} from '../src/render/streamingLodSize';
+import { POINT_STYLE_DEFAULTS } from '../src/render/pointStyle';
+import type { RefinementPhase } from '../src/render/refinementPhase';
+
+const PHASES: RefinementPhase[] = ['moving', 'coverage', 'center-refine', 'full-refine'];
+
+describe('relativeNodeResolution', () => {
+  it('is the node/root ratio, clamped to 1 at the root', () => {
+    expect(relativeNodeResolution(2, 4)).toBeCloseTo(0.5, 12);
+    expect(relativeNodeResolution(4, 4)).toBe(1);
+    expect(relativeNodeResolution(8, 4)).toBe(1);
+  });
+
+  it('refuses an unusable root resolution — no compensation', () => {
+    for (const bad of [0, -1, NaN, Infinity, -Infinity]) {
+      expect(relativeNodeResolution(2, bad)).toBe(0);
+    }
+  });
+
+  it('refuses an unusable node resolution — no compensation', () => {
+    for (const bad of [0, -1, NaN, Infinity, -Infinity]) {
+      expect(relativeNodeResolution(bad, 4)).toBe(0);
+    }
+  });
+});
+
+describe('coarseLodScale', () => {
+  it('gives the root node the maximum bounded scale while moving', () => {
+    expect(coarseLodScale(1, 'moving', 'adaptive')).toBeCloseTo(MAX_LOD_SCALE, 12);
+  });
+
+  it('gives a finer node a smaller scale than a coarser one', () => {
+    const coarse = coarseLodScale(1, 'moving', 'adaptive');
+    const mid = coarseLodScale(0.5, 'moving', 'adaptive');
+    const fine = coarseLodScale(0.125, 'moving', 'adaptive');
+    expect(mid).toBeLessThan(coarse);
+    expect(fine).toBeLessThan(mid);
+    expect(fine).toBeGreaterThan(1);
+  });
+
+  it('converges to exactly 1 in full-refine — settled sizing is unchanged', () => {
+    expect(phaseLodGain('full-refine')).toBe(0);
+    for (const rel of [0, 0.25, 0.5, 1]) {
+      expect(coarseLodScale(rel, 'full-refine', 'adaptive')).toBe(1);
+      expect(coarseLodScale(rel, 'full-refine', 'density')).toBe(1);
+    }
+  });
+
+  it('steps down through the phases at a fixed resolution', () => {
+    const at = (p: RefinementPhase) => coarseLodScale(1, p, 'adaptive');
+    expect(at('moving')).toBe(at('coverage'));
+    expect(at('center-refine')).toBeLessThan(at('coverage'));
+    expect(at('full-refine')).toBeLessThan(at('center-refine'));
+  });
+
+  it('leaves fixed mode untouched in every phase and at every resolution', () => {
+    for (const phase of PHASES) {
+      for (const rel of [0, 0.3, 1, NaN, -5]) {
+        expect(coarseLodScale(rel, phase, 'fixed')).toBe(1);
+      }
+    }
+  });
+
+  it('is finite and inside [1, MAX_LOD_SCALE] for any input', () => {
+    const inputs = [0, -0, -1, -1e9, 0.001, 0.5, 1, 2, 1e9, NaN, Infinity, -Infinity];
+    for (const phase of PHASES) {
+      for (const mode of ['adaptive', 'density', 'fixed'] as const) {
+        for (const rel of inputs) {
+          const s = coarseLodScale(rel, phase, mode);
+          expect(Number.isFinite(s)).toBe(true);
+          expect(s).toBeGreaterThanOrEqual(1);
+          expect(s).toBeLessThanOrEqual(MAX_LOD_SCALE);
+        }
+      }
+    }
+  });
+});
+
+describe('maxCompensatedPointSize', () => {
+  it('is the existing adaptive maximum times the largest LOD scale', () => {
+    const base = 2;
+    const existing = base * POINT_STYLE_DEFAULTS.maxSizeFactor;
+    expect(maxCompensatedPointSize(base, POINT_STYLE_DEFAULTS.maxSizeFactor)).toBeCloseTo(
+      existing * MAX_LOD_SCALE,
+      12,
+    );
+    expect(MAX_COMPENSATED_SIZE_FACTOR).toBeCloseTo(
+      POINT_STYLE_DEFAULTS.maxSizeFactor * MAX_LOD_SCALE,
+      12,
+    );
+  });
+
+  it('bounds the compensated adaptive size for every phase and resolution', () => {
+    const base = 3;
+    const cap = maxCompensatedPointSize(base, POINT_STYLE_DEFAULTS.maxSizeFactor);
+    const adaptiveMax = base * POINT_STYLE_DEFAULTS.maxSizeFactor;
+    for (const phase of PHASES) {
+      for (const rel of [0, 0.5, 1, NaN, Infinity]) {
+        const sized = adaptiveMax * coarseLodScale(rel, phase, 'adaptive');
+        expect(sized).toBeLessThanOrEqual(cap + 1e-12);
+        expect(sized).toBeGreaterThanOrEqual(POINT_STYLE_DEFAULTS.minSizePx);
+      }
+    }
+  });
+});
+
+// --- uniform bookkeeping -------------------------------------------------
+
+/** A node stand-in recording the operations the fold applies to it. */
+interface FakeNode {
+  op: string;
+  args: unknown[];
+  add(o: unknown): FakeNode;
+  mul(o: unknown): FakeNode;
+  clamp(lo: unknown, hi: unknown): FakeNode;
+}
+
+function fakeNode(op: string, args: unknown[] = []): FakeNode {
+  return {
+    op,
+    args,
+    add: (o) => fakeNode('add', [op, o]),
+    mul: (o) => fakeNode('mul', [op, o]),
+    clamp: (lo, hi) => fakeNode('clamp', [op, lo, hi]),
+  };
+}
+
+function harness() {
+  let made = 0;
+  const uniform = (value: number) => {
+    made++;
+    return { value };
+  };
+  const nodes = new CoarseLodSizeNodes(uniform, fakeNode('base'), fakeNode('min'));
+  return { nodes, made: () => made };
+}
+
+function material(node: number, root: number): { userData: Record<string, unknown> } {
+  const m = { userData: {} as Record<string, unknown> };
+  markNodeResolution(m.userData, node, root);
+  return m;
+}
+
+describe('CoarseLodSizeNodes', () => {
+  it('starts at the settled gain — nothing is enlarged until a phase says so', () => {
+    expect(harness().nodes.phaseGain).toBe(PHASE_LOD_GAIN['full-refine']);
+  });
+
+  it('registers one uniform per material and reports first registration', () => {
+    const h = harness();
+    const a = material(4, 4);
+    expect(h.nodes.register(a)).toBe(true);
+    expect(h.nodes.register(a)).toBe(false);
+    const b = material(1, 4);
+    expect(h.nodes.register(b)).toBe(true);
+    // one shared gain uniform + one per material
+    expect(h.made()).toBe(3);
+  });
+
+  it('does not fold on an unregistered material or in fixed mode', () => {
+    const h = harness();
+    const m = material(4, 4);
+    expect(h.nodes.has(m, 'adaptive')).toBe(false);
+    h.nodes.register(m);
+    expect(h.nodes.has(m, 'adaptive')).toBe(true);
+    expect(h.nodes.has(m, 'density')).toBe(true);
+    expect(h.nodes.has(m, 'fixed')).toBe(false);
+    const untouched = fakeNode('size');
+    expect(h.nodes.apply(untouched, material(4, 4))).toBe(untouched);
+  });
+
+  it('a phase change writes the shared uniform and creates nothing', () => {
+    const h = harness();
+    h.nodes.register(material(4, 4));
+    const before = h.made();
+    h.nodes.setPhase('moving');
+    expect(h.nodes.phaseGain).toBe(1);
+    h.nodes.setPhase('center-refine');
+    expect(h.nodes.phaseGain).toBe(0.5);
+    h.nodes.setPhase('full-refine');
+    expect(h.nodes.phaseGain).toBe(0);
+    expect(h.made()).toBe(before);
+  });
+
+  it('applies the compensated clamp to the folded size', () => {
+    const h = harness();
+    const m = material(4, 4);
+    h.nodes.register(m);
+    const folded = h.nodes.apply(fakeNode('size'), m);
+    expect(folded.op).toBe('clamp');
+    expect(folded.args[0]).toBe('add');
+    expect((folded.args[2] as FakeNode).op).toBe('mul');
+    expect((folded.args[2] as FakeNode).args).toEqual(['base', MAX_COMPENSATED_SIZE_FACTOR]);
+  });
+
+  it('forgets a material so a removed streaming mesh stops folding', () => {
+    const h = harness();
+    const m = material(4, 4);
+    h.nodes.register(m);
+    h.nodes.forget(m);
+    expect(h.nodes.has(m, 'adaptive')).toBe(false);
+    expect(h.nodes.register(m)).toBe(true);
+  });
+
+  it('registers an unusable resolution pair at the identity scale', () => {
+    const h = harness();
+    const m = { userData: {} as Record<string, unknown> };
+    expect(h.nodes.register(m)).toBe(true);
+    expect(coarseLodScale(0, 'moving', 'adaptive')).toBe(1);
+  });
+});


### PR DESCRIPTION
Coarse streaming nodes render sparse samples that read as disconnected while a view is still refining. A render-only multiplier enlarges them slightly and fades to today's sizing as refinement completes.

`nodeLodScale = 1 + phaseGain × (MAX_LOD_SCALE − 1) × relativeResolution`, clamped to `[1, 1.6]`. Gains are 1 while moving and covering, 0.5 in center-refine and 0 in full-refine, so a settled view converges to exactly the current size. `relativeResolution` is a within-source ratio (node spacing over the root's, resolved once per source), because COPC spacing, EPT depth proxies and 3D Tiles geometric error are not comparable across formats. Non-finite input yields 0, meaning no compensation.

The multiplier folds into the existing `_applySizeMode` graph on streaming materials only, driven by uniforms so a phase change rebuilds nothing. Fixed mode is untouched.
