### PR TITLE
fix(ui): count each streamed node's classes once per session

### DIFF
--- a/src/app/AppRuntime.ts
+++ b/src/app/AppRuntime.ts
@@ -11,6 +11,7 @@
 
 import { createAppContext, type AppContext } from './appContext';
 import { createLayerIdentityService, type LayerIdentityService } from './layerIdentityService';
+import { createStreamingClassLedger, type StreamingClassLedger } from './streamingClassLedger';
 
 /** The composition root: shared state now, extracted services as they land. */
 export interface AppRuntime {
@@ -22,9 +23,20 @@ export interface AppRuntime {
    * state, rather than as a module-level singleton in the shell.
    */
   readonly layerIdentity: LayerIdentityService;
+  /**
+   * The session tally of classification counts over the UNIQUE streamed nodes
+   * decoded so far. DISPLAY ONLY — it feeds the class legend and nothing
+   * scientific. Held here so the shell keeps exactly one per session and can
+   * reset it from every path that changes the streaming dataset.
+   */
+  readonly streamingClasses: StreamingClassLedger;
 }
 
 /** Construct the runtime with a fresh, empty AppContext and its services. */
 export function createAppRuntime(): AppRuntime {
-  return { context: createAppContext(), layerIdentity: createLayerIdentityService() };
+  return {
+    context: createAppContext(),
+    layerIdentity: createLayerIdentityService(),
+    streamingClasses: createStreamingClassLedger(),
+  };
 }

--- a/src/app/streamingClassLedger.ts
+++ b/src/app/streamingClassLedger.ts
@@ -1,0 +1,106 @@
+/**
+ * streamingClassLedger.ts — one classification tally per streaming session,
+ * counted once per node.
+ *
+ * The streaming node lifecycle is deliberately cyclic: a node decodes, becomes
+ * resident, is evicted under memory pressure, and decodes again when the camera
+ * returns to it. The classification legend folded EVERY arrival into its
+ * running total, and the node-ready hook carried no identity, so the
+ * accumulator could not tell a first arrival from a reload. Navigating away and
+ * back added the same source points a second time, and the displayed totals
+ * grew with navigation history until they exceeded the number of distinct
+ * points the session had ever decoded.
+ *
+ * THE STATISTIC THIS KEEPS. Classification counts from the UNIQUE decoded
+ * source nodes seen during the current streaming session. A first encounter
+ * counts; an eviction keeps the historical count; a reload counts nothing
+ * further. That is deliberately NOT a resident-only histogram: that is a
+ * different quantity, it would have to subtract on eviction, and the legend
+ * caption states the one this ledger actually holds.
+ *
+ * IDENTITY. The caller passes the streaming node record's own id
+ * (`StreamingNodeRecord.id`, the deterministic `"depth-x-y-z"` string), which is
+ * what the scheduler, the renderer and the benchmark already key a node by. It
+ * survives eviction and reload, unlike array identity, mesh identity, decode
+ * order or a hash of the classification bytes. It is unique only WITHIN one
+ * source, so {@link StreamingClassLedger.reset} is mandatory whenever the
+ * streaming dataset changes; without it, dataset B's node "0-1-2" would be
+ * suppressed by dataset A's.
+ *
+ * DISPLAY ONLY, ONE WAY. The legend and the inspector's "k of M classes" scope
+ * stamp are the only readers. Terrain ground filtering, classification fitness,
+ * DTM / DSM / CHM, contours, the ground-return ratio, evidence records,
+ * passports, method and product digests and every export build their own
+ * populations from their own inputs and never consult this. Nothing here is a
+ * scientific quantity.
+ *
+ * Pure app state — no DOM, no three.js, no viewer — so the whole contract is
+ * unit-tested in Node.
+ */
+
+import { countClasses } from '../render/class/classHistogram';
+
+/** The per-session, count-each-node-once classification tally. */
+export interface StreamingClassLedger {
+  /**
+   * Fold one decoded node's classification into the session tally.
+   *
+   * Returns that node's OWN per-class histogram the first time `nodeId` is
+   * seen, and null for every later arrival of the same id, so the caller can
+   * use the return value directly as the legend's delta. A repeat arrival costs
+   * one set lookup and no pass over the points.
+   *
+   * NODES WITH NO CLASSIFICATION CHANNEL never reach here, and that is the
+   * deliberate choice: `buildSchedulerCallbacks` skips the hook when a decoded
+   * chunk carries no `classification` array. Folding zeros in would put the
+   * node's whole point count under class 0, stating that every one of its
+   * points is "never classified" — a claim about the source, where the truth is
+   * that the source makes no claim at all. Such a node is in neither the tally
+   * nor its denominator. An EMPTY buffer is a different thing: it is a
+   * classification population of zero points, so it is recorded as seen and
+   * contributes nothing.
+   */
+  record(nodeId: string, classification: Uint8Array): Map<number, number> | null;
+  /** The session tally, summed over every unique node recorded. A fresh copy. */
+  aggregate(): Map<number, number>;
+  /** How many unique nodes have been counted this session. */
+  size(): number;
+  /**
+   * Drop every id and the tally. MANDATORY whenever the streaming dataset
+   * changes — scan closed, new scan opened, streaming session replaced, source
+   * detached — because a node id is unique only within its own source.
+   * Idempotent, so every teardown path may call it.
+   */
+  reset(): void;
+}
+
+export function createStreamingClassLedger(): StreamingClassLedger {
+  /**
+   * Node ids counted so far. Ids, not histograms: a per-node histogram has no
+   * further reader once its counts are in `totals`, and holding the decoded
+   * arrays would keep a streaming session's whole classification in memory.
+   */
+  const seen = new Set<string>();
+  const totals = new Map<number, number>();
+
+  return {
+    record(nodeId: string, classification: Uint8Array): Map<number, number> | null {
+      if (seen.has(nodeId)) return null;
+      // Count BEFORE marking the node seen. A decode that failed earlier never
+      // reaches this hook at all, and if the population cannot be walked here
+      // the throw leaves the id unrecorded, so a later successful decode of the
+      // same node still counts exactly once rather than being suppressed by a
+      // failure that contributed nothing.
+      const histogram = countClasses(classification);
+      seen.add(nodeId);
+      for (const [code, n] of histogram) totals.set(code, (totals.get(code) ?? 0) + n);
+      return histogram;
+    },
+    aggregate: (): Map<number, number> => new Map(totals),
+    size: (): number => seen.size,
+    reset(): void {
+      seen.clear();
+      totals.clear();
+    },
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2325,26 +2325,23 @@ function refreshScopedReport(): void {
   const cloud = scans.activeCloud();
   if (cloud) inspector.setReport(runModules(cloud, currentClassScope(cloud)));
 }
-// Streaming node-ready: fold each newly-resident node's classification into the
-// legend so a class first seen at depth appears as a new row. The legend keeps
-// its current visibility (default visible, but left hidden if the user isolated
-// a class), so a late arrival never silently re-reveals hidden points.
+// Streaming node-ready: fold each newly-decoded node's classification into the
+// legend so a class first seen at depth appears as a new row. The session ledger
+// counts each node id once, so an evicted node that streams back in is not added
+// twice. The legend keeps its current visibility (default visible, but left
+// hidden if the user isolated a class), so a late arrival never re-reveals points.
 // Deferred: `viewer` is null until the lazy Viewer chunk resolves, so this hook
 // must be attached inside viewerLoaded (a top-level `viewer.*` write throws at
 // module load and breaks startup — caught by lint:main-deferral).
 void viewerLoaded.then(() => {
-  viewer.onStreamingNodeClasses = (classes) => {
+  viewer.onStreamingNodeClasses = (nodeId, classes) => {
+    const fresh = runtime.streamingClasses.record(nodeId, classes);
+    if (!fresh) return; // already counted this session: an evicted node re-decoded
     if (!classLegendPanel.hasClasses()) {
-      // First node to carry classification on this streaming scan — seed + show.
-      classLegendPanel.setClasses(countClasses(classes));
-      // Streaming counts are a running tally over decoded nodes (folded below
-      // as more arrive), not full-file totals — disclose that in the legend.
-      // setClasses() resets the flag, so set it after seeding.
+      classLegendPanel.setClasses(fresh); // clears the streaming flag, re-set next
       classLegendPanel.setStreamingMode(true);
       if (classLegendPanel.hasClasses()) classLegendPanel.show();
-    } else {
-      classLegendPanel.mergeClasses(countClasses(classes));
-    }
+    } else classLegendPanel.mergeClasses(fresh);
     // A late-arriving class can change the present-class total, so refresh the
     // inspector's scope stamp ("k of M classes") to keep M accurate.
     syncInspectClassScope();
@@ -4954,6 +4951,7 @@ async function handleRemoteCopc(url: string, signal?: AbortSignal): Promise<void
 function closeStreaming(): void {
   // A new streaming scan must re-seed its filter controls from its own data.
   streamingFilterSeeded = false;
+  runtime.streamingClasses.reset(); // a node id is unique only within its own source
   // Finalize the benchmark (if any) before tearing the session down — we
   // want the final cache snapshot and peak resident counters to be observed.
   // The post-session report is logged only under `?benchmark=1`; `?debug=1`
@@ -5249,6 +5247,7 @@ function resetToEmptyState(): void {
   // Hide + clear the class legend (and Process Studio) so neither lingers with a
   // stale scan after close. v0.4.1.
   classLegendPanel.setClasses(new Map());
+  runtime.streamingClasses.reset(); // no scan, so no streamed class tally either
   classLegendPanel.hide();
   hideReclassifyUi();
   // Clear the inspector's copy/JSON scope stamp now there's no active filter.
@@ -5457,6 +5456,7 @@ function removeCloud(id: string): void {
 function clearOpenStaticLayers(): void {
   lastDerivedConfidence = null;
   lastStreamingReportCloud = null; // every streaming open commits before calling this, so a streaming→streaming swap retires the previous scan's report here too; that path never reaches `closeStreaming`
+  runtime.streamingClasses.reset(); // and its streamed class tally with it, so B's node ids start clean
   for (const id of viewer.clouds()) {
     viewer.removeCloud(id);
     inspector.removeCloud(id);

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -3436,12 +3436,12 @@ export class Viewer {
    */
   /**
    * Optional host hook fired once per streaming node as it becomes resident,
-   * with that node's decoded per-point classification. DISPLAY-ONLY: lets the
-   * classification legend fold late-arriving nodes into its histogram. Set to
-   * `undefined` to detach. Never invoked for static clouds (the host already
-   * has their full classification buffer at load time).
+   * with its canonical id (`StreamingNodeRecord.id`) and its decoded per-point
+   * classification. DISPLAY-ONLY: the id lets the host count each node once,
+   * since an evicted node re-decodes on the way back. Set to `undefined` to
+   * detach. Never invoked for static clouds (the host has their full buffer).
    */
-  onStreamingNodeClasses?: (classes: Uint8Array) => void;
+  onStreamingNodeClasses?: (nodeId: string, classes: Uint8Array) => void;
 
   /**
    * Optional host hook fired once per streaming node as it becomes resident

--- a/src/render/streaming/streamingAttach.ts
+++ b/src/render/streaming/streamingAttach.ts
@@ -82,9 +82,10 @@ export interface StreamingHost {
   /**
    * The display-only per-node classification hook, read fresh on every
    * node-ready so a late `undefined`/reassignment takes effect. Fires the
-   * classification legend's late-node fold.
+   * classification legend's late-node fold, keyed on the node's canonical id so
+   * the host counts each node once across eviction and re-decode.
    */
-  streamingNodeClassesHook(): ((classes: Uint8Array) => void) | undefined;
+  streamingNodeClassesHook(): ((nodeId: string, classes: Uint8Array) => void) | undefined;
   /**
    * The geometry-level per-node hook, read fresh on every node-ready — lets the
    * host re-route the scan type as a sparse early cloud fills in.
@@ -121,15 +122,18 @@ export function shouldFadeIn(isMobile: boolean, quality: StreamingQuality): bool
 export function buildSchedulerCallbacks(deps: {
   renderer: Pick<StreamingRenderer, 'onNodeReady' | 'onNodeEvicted' | 'applyReplaceVisibility'>;
   benchmark: StreamingBenchmark | null;
-  nodeClassesHook(): ((classes: Uint8Array) => void) | undefined;
+  nodeClassesHook(): ((nodeId: string, classes: Uint8Array) => void) | undefined;
   nodeReadyHook(): (() => void) | undefined;
 }): SchedulerCallbacks {
   const { renderer, benchmark, nodeClassesHook, nodeReadyHook } = deps;
   return {
     onNodeReady: (node: StreamingNode, decoded: DecodedChunk): void => {
       renderer.onNodeReady(node, decoded);
-      // DISPLAY-ONLY class legend hook — hand the host the node's decoded
-      // per-point classification so the legend can fold its histogram in. The
+      // DISPLAY-ONLY class legend hook — hand the host the node's CANONICAL id
+      // and its decoded per-point classification so the legend can fold its
+      // histogram in. The id is what makes the fold idempotent: a node evicted
+      // under memory pressure re-decodes when the camera returns, and without it
+      // the host counted the same source points again on every return trip. The
       // channel is optional on a DecodedChunk, and a node from a format that
       // carries none is skipped: folding zeros in would build a histogram
       // claiming every point is "never classified". Pure read; never touches
@@ -137,7 +141,7 @@ export function buildSchedulerCallbacks(deps: {
       const classesHook = nodeClassesHook();
       if (classesHook && decoded.classification) {
         try {
-          classesHook(decoded.classification);
+          classesHook(node.record.id, decoded.classification);
         } catch {
           /* a legend refresh must never break the streaming pipeline */
         }

--- a/src/ui/ClassLegendPanel.ts
+++ b/src/ui/ClassLegendPanel.ts
@@ -96,7 +96,7 @@ export class ClassLegendPanel {
   /** True when the shown classification was OLV-derived, not producer-carried. */
   private _derived = false;
 
-  /** "Counts accrue as the cloud streams" caption (hidden unless streaming). */
+  /** "Counts from unique decoded nodes" caption (hidden unless streaming). */
   private readonly _streamingNote: HTMLElement;
 
   /** "Counts cover the loaded display sample" caption (hidden unless sampled). */
@@ -143,16 +143,17 @@ export class ClassLegendPanel {
     this._provenance.setAttribute('role', 'note');
 
     // Streaming caption — for a COPC/EPT scan the per-class counts are a
-    // RUNNING TALLY over the nodes decoded so far (the legend folds new counts
-    // as nodes arrive), so they exceed the currently-resident point count and
-    // are not full-file totals. Shown only while streaming so a reviewer never
-    // reads "Building 7,833" as an authoritative whole-cloud figure.
+    // RUNNING TALLY over the UNIQUE nodes decoded so far (the host's session
+    // ledger folds each node id in once), so they exceed the currently-resident
+    // point count and are not full-source totals. Naming that denominator is
+    // the point: it is neither the resident set nor the file, and a reviewer
+    // must not read "Building 7,833" as an authoritative whole-cloud figure.
     // Distinct class from the "Derived (heuristic)" caption (olv-cl-derived) —
     // they're independent captions that can show at the same time, and tests /
     // styling must be able to target each on its own. Shares the caption CSS.
     this._streamingNote = el('div', {
       className: 'olv-cl-streamnote olv-hidden',
-      text: 'Counts accrue as the cloud streams — points decoded so far, not full-file totals.',
+      text: 'Counts from unique decoded nodes seen so far, not full-source totals.',
     });
     this._streamingNote.setAttribute('role', 'note');
 
@@ -328,9 +329,10 @@ export class ClassLegendPanel {
   }
 
   /**
-   * Show or hide the "Counts accrue as the cloud streams" caption. The host
-   * calls this with `true` for a streaming COPC/EPT scan, so the per-class
-   * counts (a running tally over decoded nodes) never read as full-file totals.
+   * Show or hide the "Counts from unique decoded nodes" caption. The host calls
+   * this with `true` for a streaming COPC/EPT scan, so the per-class counts (a
+   * running tally over the unique nodes the session decoded) never read as
+   * full-source totals.
    */
   setStreamingMode(on: boolean): void {
     this._streamingNote.classList.toggle('olv-hidden', !on);

--- a/tests/streamingAttach.test.ts
+++ b/tests/streamingAttach.test.ts
@@ -91,8 +91,27 @@ describe('buildSchedulerCallbacks — onNodeReady', () => {
     cb.onNodeReady(node('0-0-0-0'), d);
 
     expect(renderer.onNodeReady).toHaveBeenCalledWith(node('0-0-0-0'), d);
-    expect(classesHook).toHaveBeenCalledWith(d.classification);
+    expect(classesHook).toHaveBeenCalledWith('0-0-0-0', d.classification);
     expect(readyHook).toHaveBeenCalledTimes(1);
+  });
+
+  it('keys the class hook on the node CANONICAL record id, not on decode order', () => {
+    const renderer = fakeRenderer();
+    const classesHook = vi.fn();
+    const cb = buildSchedulerCallbacks({
+      renderer,
+      benchmark: null,
+      nodeClassesHook: () => classesHook,
+      nodeReadyHook: () => undefined,
+    });
+    // The same node evicted and re-decoded arrives with a FRESH classification
+    // array, later in the order, and still carries the same record id — which is
+    // what lets the host count it once. Anything derived from the array, the
+    // mesh or the arrival index would read the two as different nodes.
+    cb.onNodeReady(node('3-4-5-6'), decoded({ classification: new Uint8Array([2, 2]) }));
+    cb.onNodeReady(node('7-0-0-0'), decoded({ classification: new Uint8Array([6]) }));
+    cb.onNodeReady(node('3-4-5-6'), decoded({ classification: new Uint8Array([2, 2]) }));
+    expect(classesHook.mock.calls.map((c) => c[0])).toEqual(['3-4-5-6', '7-0-0-0', '3-4-5-6']);
   });
 
   it('forwards the replace frontier to the renderer visibility hook', () => {

--- a/tests/streamingClassLedger.test.ts
+++ b/tests/streamingClassLedger.test.ts
@@ -32,6 +32,20 @@ const NODE_A = classes({ 2: 20, 5: 80 });
 const NODE_B = classes({ 2: 10, 6: 30 });
 const NODE_C = classes({ 9: 5 });
 
+/** A ledger that has already seen nodes A and B, the shared starting point. */
+function ledgerWithAandB() {
+  const ledger = createStreamingClassLedger();
+  ledger.record('0-0-0-0', NODE_A);
+  ledger.record('1-0-0-0', NODE_B);
+  return ledger;
+}
+
+/** The tally after A and B, asserted the same way wherever it must not move. */
+function expectAandBTally(ledger: ReturnType<typeof createStreamingClassLedger>): void {
+  expect(asObject(ledger.aggregate())).toEqual({ 2: 30, 5: 80, 6: 30 });
+  expect(ledger.size()).toBe(2);
+}
+
 describe('streaming class ledger — unique nodes only', () => {
   it('counts the first node it sees', () => {
     const ledger = createStreamingClassLedger();
@@ -41,31 +55,23 @@ describe('streaming class ledger — unique nodes only', () => {
   });
 
   it('folds a second, distinct node into the same tally', () => {
-    const ledger = createStreamingClassLedger();
-    ledger.record('0-0-0-0', NODE_A);
-    ledger.record('1-0-0-0', NODE_B);
+    const ledger = ledgerWithAandB();
     expect(asObject(ledger.aggregate())).toEqual({ 2: 30, 5: 80, 6: 30 });
     expect(ledger.size()).toBe(2);
   });
 
   it('keeps an evicted node in the tally (the ledger is never told about eviction)', () => {
-    const ledger = createStreamingClassLedger();
-    ledger.record('0-0-0-0', NODE_A);
-    ledger.record('1-0-0-0', NODE_B);
+    const ledger = ledgerWithAandB();
     // Eviction happens in the scheduler and has NO entry point here: the
     // statistic is "unique nodes seen", not "nodes currently resident", so the
     // historical count stands after the node leaves the GPU.
-    expect(asObject(ledger.aggregate())).toEqual({ 2: 30, 5: 80, 6: 30 });
-    expect(ledger.size()).toBe(2);
+    expectAandBTally(ledger);
   });
 
   it('adds nothing when an evicted node is decoded again', () => {
-    const ledger = createStreamingClassLedger();
-    ledger.record('0-0-0-0', NODE_A);
-    ledger.record('1-0-0-0', NODE_B);
+    const ledger = ledgerWithAandB();
     expect(ledger.record('0-0-0-0', NODE_A)).toBeNull();
-    expect(asObject(ledger.aggregate())).toEqual({ 2: 30, 5: 80, 6: 30 });
-    expect(ledger.size()).toBe(2);
+    expectAandBTally(ledger);
   });
 
   it('adds nothing however many times the same node comes back', () => {
@@ -79,9 +85,7 @@ describe('streaming class ledger — unique nodes only', () => {
   });
 
   it('adds only the new node when a fresh id arrives among reloads', () => {
-    const ledger = createStreamingClassLedger();
-    ledger.record('0-0-0-0', NODE_A);
-    ledger.record('1-0-0-0', NODE_B);
+    const ledger = ledgerWithAandB();
     ledger.record('0-0-0-0', NODE_A); // reload
     expect(asObject(ledger.record('2-1-1-1', NODE_C) ?? new Map())).toEqual({ 9: 5 });
     expect(asObject(ledger.aggregate())).toEqual({ 2: 30, 5: 80, 6: 30, 9: 5 });
@@ -104,9 +108,7 @@ describe('streaming class ledger — unique nodes only', () => {
 
 describe('streaming class ledger — session reset', () => {
   it('clears the ids and the tally when the dataset changes', () => {
-    const ledger = createStreamingClassLedger();
-    ledger.record('0-0-0-0', NODE_A);
-    ledger.record('1-0-0-0', NODE_B);
+    const ledger = ledgerWithAandB();
     ledger.reset();
     expect(asObject(ledger.aggregate())).toEqual({});
     expect(ledger.size()).toBe(0);

--- a/tests/streamingClassLedger.test.ts
+++ b/tests/streamingClassLedger.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The streaming classification ledger's session contract.
+ *
+ * The legend used to fold EVERY node arrival into its running total, and the
+ * streaming node lifecycle deliberately re-decodes a node the camera comes back
+ * to, so the same source points were added again on every return trip and the
+ * displayed totals grew with navigation history. These tests pin the statistic
+ * that replaces it: classification counts over the UNIQUE decoded nodes seen in
+ * the current streaming session. First encounter counts, eviction keeps the
+ * historical count, reload counts nothing further, and a dataset change clears
+ * both the ids and the tally because a node id is unique only within a source.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createStreamingClassLedger } from '../src/app/streamingClassLedger';
+
+/** A classification buffer holding exactly the requested per-code counts. */
+function classes(counts: Record<number, number>): Uint8Array {
+  const codes: number[] = [];
+  for (const [code, n] of Object.entries(counts)) {
+    for (let i = 0; i < n; i++) codes.push(Number(code));
+  }
+  return new Uint8Array(codes);
+}
+
+/** The aggregate as a plain object, so expectations read as class → count. */
+function asObject(m: Map<number, number>): Record<number, number> {
+  return Object.fromEntries(m);
+}
+
+const NODE_A = classes({ 2: 20, 5: 80 });
+const NODE_B = classes({ 2: 10, 6: 30 });
+const NODE_C = classes({ 9: 5 });
+
+describe('streaming class ledger — unique nodes only', () => {
+  it('counts the first node it sees', () => {
+    const ledger = createStreamingClassLedger();
+    expect(ledger.record('0-0-0-0', NODE_A)).not.toBeNull();
+    expect(asObject(ledger.aggregate())).toEqual({ 2: 20, 5: 80 });
+    expect(ledger.size()).toBe(1);
+  });
+
+  it('folds a second, distinct node into the same tally', () => {
+    const ledger = createStreamingClassLedger();
+    ledger.record('0-0-0-0', NODE_A);
+    ledger.record('1-0-0-0', NODE_B);
+    expect(asObject(ledger.aggregate())).toEqual({ 2: 30, 5: 80, 6: 30 });
+    expect(ledger.size()).toBe(2);
+  });
+
+  it('keeps an evicted node in the tally (the ledger is never told about eviction)', () => {
+    const ledger = createStreamingClassLedger();
+    ledger.record('0-0-0-0', NODE_A);
+    ledger.record('1-0-0-0', NODE_B);
+    // Eviction happens in the scheduler and has NO entry point here: the
+    // statistic is "unique nodes seen", not "nodes currently resident", so the
+    // historical count stands after the node leaves the GPU.
+    expect(asObject(ledger.aggregate())).toEqual({ 2: 30, 5: 80, 6: 30 });
+    expect(ledger.size()).toBe(2);
+  });
+
+  it('adds nothing when an evicted node is decoded again', () => {
+    const ledger = createStreamingClassLedger();
+    ledger.record('0-0-0-0', NODE_A);
+    ledger.record('1-0-0-0', NODE_B);
+    expect(ledger.record('0-0-0-0', NODE_A)).toBeNull();
+    expect(asObject(ledger.aggregate())).toEqual({ 2: 30, 5: 80, 6: 30 });
+    expect(ledger.size()).toBe(2);
+  });
+
+  it('adds nothing however many times the same node comes back', () => {
+    const ledger = createStreamingClassLedger();
+    ledger.record('0-0-0-0', NODE_A);
+    for (let i = 0; i < 25; i++) {
+      expect(ledger.record('0-0-0-0', NODE_A)).toBeNull();
+    }
+    expect(asObject(ledger.aggregate())).toEqual({ 2: 20, 5: 80 });
+    expect(ledger.size()).toBe(1);
+  });
+
+  it('adds only the new node when a fresh id arrives among reloads', () => {
+    const ledger = createStreamingClassLedger();
+    ledger.record('0-0-0-0', NODE_A);
+    ledger.record('1-0-0-0', NODE_B);
+    ledger.record('0-0-0-0', NODE_A); // reload
+    expect(asObject(ledger.record('2-1-1-1', NODE_C) ?? new Map())).toEqual({ 9: 5 });
+    expect(asObject(ledger.aggregate())).toEqual({ 2: 30, 5: 80, 6: 30, 9: 5 });
+    expect(ledger.size()).toBe(3);
+  });
+
+  it('returns the new node own histogram, not the running total', () => {
+    const ledger = createStreamingClassLedger();
+    ledger.record('0-0-0-0', NODE_A);
+    expect(asObject(ledger.record('1-0-0-0', NODE_B) ?? new Map())).toEqual({ 2: 10, 6: 30 });
+  });
+
+  it('hands back a detached aggregate a caller cannot mutate into the ledger', () => {
+    const ledger = createStreamingClassLedger();
+    ledger.record('0-0-0-0', NODE_A);
+    ledger.aggregate().set(2, 9999);
+    expect(asObject(ledger.aggregate())).toEqual({ 2: 20, 5: 80 });
+  });
+});
+
+describe('streaming class ledger — session reset', () => {
+  it('clears the ids and the tally when the dataset changes', () => {
+    const ledger = createStreamingClassLedger();
+    ledger.record('0-0-0-0', NODE_A);
+    ledger.record('1-0-0-0', NODE_B);
+    ledger.reset();
+    expect(asObject(ledger.aggregate())).toEqual({});
+    expect(ledger.size()).toBe(0);
+  });
+
+  it('lets dataset B count ids identical to dataset A after the reset', () => {
+    const ledger = createStreamingClassLedger();
+    ledger.record('0-0-0-0', NODE_A); // dataset A
+    ledger.reset(); // dataset B opens
+    // A node id is only unique WITHIN a source, so B's "0-0-0-0" is a different
+    // node and must not be suppressed by A's.
+    expect(ledger.record('0-0-0-0', NODE_C)).not.toBeNull();
+    expect(asObject(ledger.aggregate())).toEqual({ 9: 5 });
+    expect(ledger.size()).toBe(1);
+  });
+
+  it('is idempotent, so repeated resets are safe from every teardown path', () => {
+    const ledger = createStreamingClassLedger();
+    ledger.record('0-0-0-0', NODE_A);
+    ledger.reset();
+    ledger.reset();
+    expect(ledger.size()).toBe(0);
+    expect(asObject(ledger.aggregate())).toEqual({});
+  });
+});
+
+describe('streaming class ledger — failed decodes', () => {
+  it('does not mark a node seen when counting its population throws', () => {
+    const ledger = createStreamingClassLedger();
+    // A buffer that fails part-way through the count stands in for a decode
+    // whose classification population was never validly processed.
+    const broken = {
+      *[Symbol.iterator](): Generator<number> {
+        yield 2;
+        throw new Error('decode failed');
+      },
+    } as unknown as Uint8Array;
+    expect(() => ledger.record('0-0-0-0', broken)).toThrow('decode failed');
+    expect(ledger.size()).toBe(0);
+    expect(asObject(ledger.aggregate())).toEqual({});
+  });
+
+  it('counts a node exactly once when a later decode of it succeeds', () => {
+    const ledger = createStreamingClassLedger();
+    const broken = {
+      *[Symbol.iterator](): Generator<number> {
+        throw new Error('decode failed');
+      },
+    } as unknown as Uint8Array;
+    expect(() => ledger.record('0-0-0-0', broken)).toThrow();
+    expect(ledger.record('0-0-0-0', NODE_A)).not.toBeNull();
+    expect(ledger.record('0-0-0-0', NODE_A)).toBeNull();
+    expect(asObject(ledger.aggregate())).toEqual({ 2: 20, 5: 80 });
+    expect(ledger.size()).toBe(1);
+  });
+
+  it('records an empty classification buffer as a seen node with no counts', () => {
+    const ledger = createStreamingClassLedger();
+    expect(ledger.record('0-0-0-0', new Uint8Array(0))).not.toBeNull();
+    expect(asObject(ledger.aggregate())).toEqual({});
+    expect(ledger.size()).toBe(1);
+  });
+});
+
+describe('streaming class ledger — denominator invariant', () => {
+  it('never totals more than the points of the unique nodes it counted', () => {
+    const ledger = createStreamingClassLedger();
+    const arrivals: Array<[string, Uint8Array]> = [
+      ['0-0-0-0', NODE_A],
+      ['1-0-0-0', NODE_B],
+      ['0-0-0-0', NODE_A], // reload
+      ['1-0-0-0', NODE_B], // reload
+      ['2-1-1-1', NODE_C],
+      ['0-0-0-0', NODE_A], // reload again
+    ];
+    let uniquePoints = 0;
+    const counted = new Set<string>();
+    for (const [id, buf] of arrivals) {
+      if (!counted.has(id)) {
+        counted.add(id);
+        uniquePoints += buf.length;
+      }
+      ledger.record(id, buf);
+    }
+    const total = [...ledger.aggregate().values()].reduce((a, b) => a + b, 0);
+    // The comparison is against the UNIQUE decoded population, never against
+    // whatever happens to be resident right now.
+    expect(total).toBeLessThanOrEqual(uniquePoints);
+    expect(total).toBe(uniquePoints); // every counted node carried classification
+    expect(ledger.size()).toBe(counted.size);
+  });
+});


### PR DESCRIPTION
The streaming classes callback carried no node identity, so the legend could not tell a first arrival from a reload. Node lifecycle allows decode, evict, navigate back, decode again, and each arrival merged the same points again, so displayed totals grew with navigation history until they exceeded the points ever decoded.

The callback now passes the canonical `StreamingNodeRecord.id`, stable across eviction and re-decode. A session ledger owned by `AppRuntime` keeps a set of seen ids and one summed histogram: a first arrival costs one pass, a repeat costs a set lookup, and no decoded arrays are retained. It resets when a source detaches, a scan closes, or static layers are cleared.

Nodes carrying no classification stay out of both the counts and the denominator. The caption now names the population.
