### PR TITLE
fix(report): give streaming report rows the units and labels they earned

### DIFF
--- a/docs/architecture/spatial-context-consumers.md
+++ b/docs/architecture/spatial-context-consumers.md
@@ -68,7 +68,7 @@ has re-opened the divergence this closes.
 | 12 | Measurement labels | migrated | `src/main.ts` | `linearUnitToMetres`, `linearUnitKnown`, `isGeographic`, `verticalMetresPerUnit` |
 | 13 | Elevation colorbars | migrated | `src/main.ts`, `src/app/terrainAnalysisRunner.ts` | `verticalMetresPerUnit`, `kind` |
 | 14 | Classification | migrated | `src/render/class/classifierCues.ts` | `linearUnitToMetres`, `verticalMetresPerUnit` |
-| 15 | Streaming scan-report extents | migrated | `src/analysis/streamingExtentRows.ts` | `linearUnitKnown`, `linearUnitToMetres`, `verticalMetresPerUnit` |
+| 15 | Streaming scan report | migrated | `src/analysis/streamingExtentRows.ts`, `src/app/streamingScanReport.ts` | `linearUnitKnown`, `linearUnitToMetres`, `verticalMetresPerUnit`, `isGeographic` |
 | 16 | Tool preflight | migrated | `src/process/toolPreflight.ts` | `metricClaimsPermitted`, `verticalReferenceKnown`, `crsName` |
 | 17 | Cross-CRS project placement | migrated | `src/geo/projectPlacement.ts` | vertical verdict delegated to `src/geo/frameCompatibility.ts` |
 

--- a/src/analysis/inMemoryPrecisionRows.ts
+++ b/src/analysis/inMemoryPrecisionRows.ts
@@ -1,0 +1,61 @@
+/**
+ * inMemoryPrecisionRows.ts — the two report rows that disclose what the
+ * Float32 position buffer can still tell apart.
+ *
+ * REPRESENTATIONAL RESOLUTION, not accuracy. Every other extent row on a scan
+ * card describes the survey; these two describe the STORAGE. On a wide extent
+ * the two diverge: a millimetre-quantized source file can sit in a buffer whose
+ * step is a centimetre, and nothing else on the card would say so. The wording
+ * therefore never borrows survey, sensor or vertical-accuracy vocabulary.
+ *
+ * One formatter for both report paths. The static Scan Report reads a resident
+ * `PointCloud`; the streaming report reads a header extent against a render
+ * origin. They measure different clouds, but the figure they print is the same
+ * measurement from `geo/inMemoryPrecision.ts`, so the sentence that prints it
+ * lives here rather than once per caller, where the two would drift.
+ *
+ * FAILS CLOSED on the unit: with no established linear unit there is no length
+ * to report, so the step is shown in source units and left ungraded rather than
+ * stamped with a fabricated millimetre.
+ *
+ * Pure — no DOM, no three.js. Runs unchanged in Node tests.
+ */
+
+import type { AnalysisRow } from './ModuleApi';
+import type { InMemoryPrecision } from '../geo/inMemoryPrecision';
+import { formatPrecisionMetres, precisionGradeLabel } from '../geo/inMemoryPrecision';
+
+/**
+ * The `In-memory resolution` headline plus the advanced `Quantization basis`
+ * diagnostic, in that order, for an already-measured estimate.
+ */
+export function inMemoryPrecisionRows(precision: InMemoryPrecision): AnalysisRow[] {
+  const pm = precision.metres;
+  return [
+    pm
+      ? {
+          label: 'In-memory resolution',
+          value:
+            `${formatPrecisionMetres(pm.worstCaseSpacing)} worst case, `
+            + `${formatPrecisionMetres(pm.typicalSpacing)} mean over the reach `
+            + `(${precisionGradeLabel(precision.grade)})`,
+          status: precision.grade === 'fine' ? 'info' : 'warn',
+        }
+      : {
+          label: 'In-memory resolution',
+          value:
+            `${precision.worstCaseSpacing.toPrecision(3)} (source units) worst case — `
+            + 'no linear unit declared, not graded',
+          status: 'warn',
+        },
+    {
+      label: 'Quantization basis',
+      value:
+        `Float32 positions, ${precision.governingAxis} axis, `
+        + `${precision.reach.toFixed(0)} source units from the local origin `
+        + `(${precision.localOrigin.map((n) => n.toFixed(0)).join(', ')})`,
+      status: 'info',
+      advanced: true,
+    },
+  ];
+}

--- a/src/analysis/modules/scanReport.ts
+++ b/src/analysis/modules/scanReport.ts
@@ -6,11 +6,8 @@ import type { SpatialContext } from '../../geo/SpatialContext';
 import { spatialContextFrom } from '../../geo/SpatialContext';
 import { isZUpFormat } from '../../io/sniffFormat';
 import { heightLabel } from '../../geo/height';
-import {
-  estimateInMemoryPrecision,
-  formatPrecisionMetres,
-  precisionGradeLabel,
-} from '../../geo/inMemoryPrecision';
+import { estimateInMemoryPrecision } from '../../geo/inMemoryPrecision';
+import { inMemoryPrecisionRows } from '../inMemoryPrecisionRows';
 
 function rowInfo(label: string, value: string): AnalysisRow {
   return { label, value, status: 'info' };
@@ -280,31 +277,10 @@ export const scanReport: AnalysisModule = {
         verticalUnitToMetres: zUp ? ctx.verticalUnitToMetres : undefined,
       },
     });
-    const pm = precision.metres;
+    // Both rows come from the one formatter the streaming report also uses, so
+    // the two paths cannot describe the same Float32 policy in different words.
     rows.push(
-      pm
-        ? {
-            label: 'In-memory resolution',
-            value:
-              `${formatPrecisionMetres(pm.worstCaseSpacing)} worst case, `
-              + `${formatPrecisionMetres(pm.typicalSpacing)} mean over the reach `
-              + `(${precisionGradeLabel(precision.grade)})`,
-            status: precision.grade === 'fine' ? 'info' : 'warn',
-          }
-        : rowWarn(
-            'In-memory resolution',
-            `${precision.worstCaseSpacing.toPrecision(3)} (source units) worst case — `
-              + 'no linear unit declared, not graded',
-          ),
-      {
-        label: 'Quantization basis',
-        value:
-          `Float32 positions, ${precision.governingAxis} axis, `
-          + `${precision.reach.toFixed(0)} source units from the local origin `
-          + `(${precision.localOrigin.map((n) => n.toFixed(0)).join(', ')})`,
-        status: 'info',
-        advanced: true,
-      },
+      ...inMemoryPrecisionRows(precision),
       // Attribute coverage.
       rowInfo('RGB', cloud.colors !== undefined ? 'Yes' : 'No'),
       rowInfo('Intensity', cloud.intensity !== undefined ? 'Yes' : 'No'),

--- a/src/app/streamingScanReport.ts
+++ b/src/app/streamingScanReport.ts
@@ -1,0 +1,156 @@
+/**
+ * streamingScanReport.ts — the streaming Scan Report rows whose wording is a
+ * claim about units, provenance or basis.
+ *
+ * The shell assembles the streaming report (`runStreamingModules` in
+ * `src/main.ts`) from the source's header, its COPC info VLR and its hierarchy
+ * index, in the same `AnalysisRow` shape the static Scan Report emits. Three of
+ * those groups say something the reader will act on, and each had drifted from
+ * `analysis/modules/scanReport.ts`:
+ *
+ *  - the octree root spacing carried a literal " m" whatever the source CRS's
+ *    linear unit was, so a state-plane-FEET COPC read ~3.28x too large,
+ *    labelled as metres;
+ *  - the LAS `system_identifier` was still called "Capture Sensor" after the
+ *    static report stopped calling it that, and no file-creation label existed
+ *    at all;
+ *  - the Float32 in-memory quantization was disclosed on the static side only,
+ *    although the streaming decoder writes the same Float32 positions against a
+ *    render origin (`io/copc/copcChunkDecode.ts`).
+ *
+ * Each is answered by the authority that already owns the question — the
+ * resolved {@link SpatialContext} for the unit gate, `ui/StreamingPanel`'s
+ * `spacingRowFor` for the spacing label, `app/scanPrecision.ts` over
+ * `geo/inMemoryPrecision.ts` for the step, `analysis/inMemoryPrecisionRows.ts`
+ * for the sentence that prints it — rather than by a second formula written for
+ * the report. Every one of them FAILS CLOSED: with no established linear unit
+ * the figure stays in source units and no millimetre is invented.
+ */
+
+import type { AnalysisRow } from '../analysis/ModuleApi';
+import { inMemoryPrecisionRows } from '../analysis/inMemoryPrecisionRows';
+import { scanPrecision } from './scanPrecision';
+import { spacingRowFor } from '../ui/StreamingPanel';
+import type { SpatialContext } from '../geo/SpatialContext';
+
+// Re-exported so the shell reaches every streaming report row builder through
+// one seam. The extent block's unit gate is the same `SpatialContext` gate the
+// rows below apply, and splitting the import across two modules is how the two
+// halves of one report end up maintained apart.
+export { streamingExtentRows } from '../analysis/streamingExtentRows';
+
+/** The streaming source fields the structure + precision rows read. */
+export interface StreamingStructureSource {
+  /** The Float64 origin every decoded node is recentred against; absent on a source that does not expose one. */
+  readonly renderOrigin?: readonly [number, number, number];
+  /** The octree ROOT CUBE in local space — a containment bound, never the first choice for a reach. */
+  readonly localBounds?: () => readonly [number, number, number, number, number, number];
+  readonly metadata?: {
+    readonly header?: {
+      min: readonly [number, number, number];
+      max: readonly [number, number, number];
+    };
+    readonly info?: { spacing?: number };
+  };
+  readonly maxDepth?: () => number;
+  readonly octree?: { nodes: () => readonly unknown[] };
+}
+
+/** The header provenance fields, in the shape the report cloud carries them. */
+export interface StreamingProvenanceMetadata {
+  readonly captureSensor?: string;
+  readonly sourceSoftware?: string;
+  readonly captureDate?: string;
+}
+
+const info = (label: string, value: string): AnalysisRow => ({ label, value, status: 'info' });
+
+/**
+ * What every other row in the streaming report is taken from.
+ *
+ * All of them are source DECLARATIONS — the file header, the COPC info VLR,
+ * the hierarchy index — and none is a count of the nodes decoded and uploaded
+ * at this instant. The two differ by orders of magnitude for most of a
+ * streaming session, and without the statement a reader has no way to tell a
+ * declared total from a live one.
+ */
+export function streamingReportBasisRow(): AnalysisRow {
+  return info(
+    'Report basis',
+    'source-declared header and hierarchy index, not the nodes currently resident',
+  );
+}
+
+/**
+ * The octree-structure rows, plus the Float32 disclosure the static report
+ * already carries.
+ *
+ * SPACING UNIT. COPC's `info.spacing` is a root-node point spacing in the
+ * SOURCE CRS's linear units, not metres. The unit decision is `spacingRowFor`,
+ * the same one the Streaming panel's own Spacing row applies: metres are
+ * claimed only when the resolved frame declares a real linear unit, a foot CRS
+ * is converted first, a geographic CRS has no linear spacing at all, and an
+ * unresolved unit stays in source units.
+ *
+ * IN-MEMORY RESOLUTION. Representational resolution of the stored coordinates,
+ * never survey, sensor or vertical accuracy. Measured through the one canonical
+ * reader (`app/scanPrecision.ts`) on the TIGHT header extent against the render
+ * origin the decoder actually subtracts, with the octree root cube left as that
+ * reader's own fallback for an unreadable header box — the cube over-reports
+ * the reach on the short axes. A source that exposes no render origin gets NO
+ * row: there is no frame to measure, and a figure taken from a guessed origin
+ * would describe the guess.
+ */
+export function streamingStructureRows(
+  cloud: StreamingStructureSource,
+  ctx: SpatialContext,
+): AnalysisRow[] {
+  const rows: AnalysisRow[] = [];
+  const header = cloud.metadata?.header;
+  const ro = cloud.renderOrigin;
+  if (ro && header) {
+    const precision = scanPrecision({
+      streaming: {
+        renderOrigin: ro,
+        dataBounds: () => [
+          header.min[0] - ro[0], header.min[1] - ro[1], header.min[2] - ro[2],
+          header.max[0] - ro[0], header.max[1] - ro[1], header.max[2] - ro[2],
+        ],
+        ...(cloud.localBounds ? { localBounds: cloud.localBounds } : {}),
+      },
+      crs: ctx,
+    });
+    if (precision) rows.push(...inMemoryPrecisionRows(precision));
+  }
+  const rootSpacing = cloud.metadata?.info?.spacing;
+  if (rootSpacing !== undefined) {
+    rows.push(info('Octree root spacing', spacingRowFor('copc', rootSpacing, ctx).value));
+  }
+  if (cloud.maxDepth) {
+    try { rows.push(info('Octree depth', String(cloud.maxDepth()))); }
+    catch { /* defensive — depth not always computable mid-load */ }
+  }
+  if (cloud.octree) {
+    try { rows.push(info('Octree nodes', cloud.octree.nodes().length.toLocaleString('en-US'))); }
+    catch { /* defensive */ }
+  }
+  return rows;
+}
+
+/**
+ * Header provenance, labelled by what each LAS field IS — the same labels
+ * `analysis/modules/scanReport.ts` uses, so one file cannot be described two
+ * ways depending on how it was opened.
+ *
+ * `system_identifier` names hardware OR a producing process, software or
+ * organisation, so it is never called a sensor. The File Creation Day/Year is
+ * when the file was WRITTEN, which is not when the survey was flown, so it is
+ * never called a capture date and acquisition timing is never inferred from it.
+ */
+export function streamingProvenanceRows(meta: StreamingProvenanceMetadata | undefined): AnalysisRow[] {
+  const rows: AnalysisRow[] = [];
+  if (meta?.captureSensor) rows.push(info('System identifier', meta.captureSensor));
+  if (meta?.sourceSoftware) rows.push(info('Source Software', meta.sourceSoftware));
+  if (meta?.captureDate) rows.push(info('File created', meta.captureDate));
+  return rows;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -278,7 +278,7 @@ import { CatalogPanel, buildCuratedDemoSample } from './ui/CatalogPanel';
 // section. Static clouds carry `metadata.crs` (CrsInfo from src/io/crs);
 // streaming clouds expose `.crs()` returning the same shape.
 import type { CrsLinearUnit } from './io/crs';
-import { streamingExtentRows } from './analysis/streamingExtentRows';
+import { streamingExtentRows, streamingProvenanceRows, streamingReportBasisRow, streamingStructureRows } from './app/streamingScanReport';
 import { CrsService } from './geo/CrsService';
 import { verticalMetresPerUnit } from './geo/SpatialContext';
 import { prepareEpochFrames, epochUnitMismatchLines } from './app/epochFramePrep';
@@ -4089,18 +4089,25 @@ function syncInspectClassScope(): void {
  * modules can't run as-is. We instead pull the equivalent facts directly
  * from the streaming source's header + COPC info / EPT schema, which
  * carry everything the report needs: total point count, source-declared
- * bounds, spacing, octree depth, and the LAS VLR sensor / software
- * strings the provenance classifier already feeds from.
+ * bounds, spacing, octree depth, and the LAS header provenance strings
+ * the provenance classifier already feeds from.
  *
  * The output is intentionally the same `AnalysisRow` shape the static
  * report uses, so the Inspector's Scan-report section renders uniformly
  * and the PDF Report Engine can consume it without a separate code path.
+ *
+ * Every row whose wording is a CLAIM — the unit on a length, the name of a
+ * LAS header field, the Float32 step the coordinates are stored on — is
+ * built in `app/streamingScanReport.ts` against the resolved frame this
+ * shell reads once, so it says what the static Scan Report says about the
+ * same file. This function stays the assembler.
  */
 function runStreamingModules(cloud: {
   readonly kind: StreamingSourceKind;
   readonly name: string;
   readonly sourcePointCount: number | null; // null where the format states no total: a tileset declares none, and its per-tile figures are decode-admission estimates rather than counts
   readonly localBounds?: () => readonly [number, number, number, number, number, number];
+  readonly renderOrigin?: readonly [number, number, number]; // the Float64 origin the decoder subtracts; absent on a source that exposes none, and then no precision row is minted
   readonly metadata?: {
     readonly header?: {
       min: readonly [number, number, number];
@@ -4110,6 +4117,7 @@ function runStreamingModules(cloud: {
     readonly info?: { spacing?: number };
     readonly captureSensor?: string;
     readonly sourceSoftware?: string;
+    readonly captureDate?: string;
   };
   readonly crs?: () => { readonly linearUnit?: CrsLinearUnit; readonly linearUnitToMetres?: number; readonly verticalUnitToMetres?: number } | null;
   readonly maxDepth?: () => number;
@@ -4130,6 +4138,9 @@ function runStreamingModules(cloud: {
   };
 
   rows.push(info('Source', streamingSourceLabel(cloud.kind)));
+  // Said once, before any figure: every number below is a source DECLARATION,
+  // not a count of what is decoded and on the GPU right now.
+  rows.push(streamingReportBasisRow());
   if (cloud.metadata?.header?.pointDataRecordFormat !== undefined) rows.push(info('Point format', `PDRF ${cloud.metadata.header.pointDataRecordFormat}`));
   // An absent total is reported as absent: a zero, or a summed per-tile estimate, would each read as a figure the source stands behind.
   rows.push(cloud.sourcePointCount === null ? info('Source point count', 'not stated by the source') : headerMetric('Source point count', cloud.sourcePointCount.toLocaleString('en-US')));
@@ -4161,27 +4172,16 @@ function runStreamingModules(cloud: {
     }
   }
 
-  // Streaming-specific: octree structure.
-  if (cloud.metadata?.info?.spacing !== undefined) {
-    rows.push(info('Octree root spacing', `${cloud.metadata.info.spacing.toFixed(2)} m`));
-  }
-  if (cloud.maxDepth) {
-    try { rows.push(info('Octree depth', String(cloud.maxDepth()))); }
-    catch { /* defensive — depth not always computable mid-load */ }
-  }
-  if (cloud.octree) {
-    try { rows.push(info('Octree nodes', cloud.octree.nodes().length.toLocaleString('en-US'))); }
-    catch { /* defensive */ }
-  }
+  // Streaming-specific: the octree structure, and the Float32 in-memory
+  // resolution the static report already discloses. The spacing unit and the
+  // precision measurement are decided against the same resolved frame the
+  // extent block reads, and both fail closed on an unconfirmed unit.
+  rows.push(...streamingStructureRows(cloud, crsService.context()));
 
-  // Provenance metadata mirrored from the LAS VLRs the COPC header
-  // carries — same fields the static report shows.
-  if (cloud.metadata?.captureSensor) {
-    rows.push(info('Capture Sensor', cloud.metadata.captureSensor));
-  }
-  if (cloud.metadata?.sourceSoftware) {
-    rows.push(info('Source Software', cloud.metadata.sourceSoftware));
-  }
+  // Header provenance, labelled by what each LAS field IS — the same labels
+  // the static Scan Report uses, so the same file is never described two ways
+  // depending on how it was opened.
+  rows.push(...streamingProvenanceRows(cloud.metadata));
 
   return rows;
 }

--- a/src/ui/StreamingPanel.ts
+++ b/src/ui/StreamingPanel.ts
@@ -195,10 +195,20 @@ export function spacingRowFor(
   if (crs?.linearUnit === 'foot' || crs?.linearUnit === 'us-survey-foot') {
     // Spacing is in feet; convert to metres so the number is comparable.
     const factor = crs.linearUnitToMetres;
-    const metres = Number.isFinite(factor) ? spacing * (factor as number) : spacing;
+    // A foot CRS that carries no usable metre factor cannot be converted, and
+    // the unconverted figure is feet. Returning it under " m" was the same
+    // ~3.28x overstatement this function exists to stop, arrived at from the
+    // other side, so the missing factor fails closed to source units instead.
+    if (factor === undefined || !Number.isFinite(factor) || factor <= 0) {
+      return {
+        label: 'Spacing',
+        value: `${spacing.toFixed(2)} (source units)`,
+        title: 'Foot CRS declares no usable metre factor — spacing shown in the source units, not metres.',
+      };
+    }
     return {
       label: 'Spacing',
-      value: `${metres.toFixed(2)} m`,
+      value: `${(spacing * factor).toFixed(2)} m`,
       title: 'Root-node point spacing, converted from the source foot unit to metres.',
     };
   }

--- a/tests/streamingScanReportParity.test.ts
+++ b/tests/streamingScanReportParity.test.ts
@@ -1,0 +1,215 @@
+/**
+ * streamingScanReportParity.test.ts
+ *
+ * The streaming Scan Report and the static one describe the same file. When
+ * they use different words for the same LAS field, or claim a unit one of them
+ * has not established, a reader cannot tell which report to believe.
+ *
+ * Four drifts are pinned here. The streaming octree spacing stamped a literal
+ * " m" on a figure that is in the SOURCE CRS's linear units, so a state-plane
+ * feet COPC read ~3.28x too large labelled as metres. The LAS
+ * `system_identifier` was still called "Capture Sensor" after the static report
+ * stopped calling it that, the field naming hardware, software, a producing
+ * process or an organisation. The LAS File Creation Day/Year is "File created",
+ * never "Captured": it is when the file was written, not when the survey was
+ * flown. And the Float32 in-memory quantization was disclosed on the static
+ * side only, although the streaming decoder writes the same Float32 positions
+ * against a render origin.
+ *
+ * The rows are composed here exactly as `runStreamingModules` composes them in
+ * `src/main.ts` — basis, extent, structure, provenance — because that shell
+ * function cannot be imported. Between them these four producers emit every row
+ * the streaming report has, so a claim made over all of them is a claim about
+ * the whole report whatever order the shell puts them in.
+ */
+
+import {
+  streamingProvenanceRows,
+  streamingReportBasisRow,
+  streamingStructureRows,
+  type StreamingStructureSource,
+} from '../src/app/streamingScanReport';
+import { streamingExtentRows } from '../src/analysis/streamingExtentRows';
+import { scanReport } from '../src/analysis/modules/scanReport';
+import { PointCloud } from '../src/model/PointCloud';
+import { spatialContextFrom, type SpatialContext } from '../src/geo/SpatialContext';
+import type { AnalysisRow } from '../src/analysis/ModuleApi';
+import type { CloudMetadata } from '../src/model/PointCloud';
+import type { CrsInfo } from '../src/io/crs';
+
+/** A resolved frame built from a minimal CRS override, as the shell resolves one. */
+function ctx(o: Partial<CrsInfo>): SpatialContext {
+  return spatialContextFrom({
+    source: 'epsg',
+    name: 'EPSG:32610',
+    linearUnit: 'metre',
+    linearUnitToMetres: 1,
+    ...o,
+  } as CrsInfo);
+}
+
+const METRE = ctx({ linearUnit: 'metre', linearUnitToMetres: 1 });
+const FOOT = ctx({ linearUnit: 'foot', linearUnitToMetres: 0.3048, name: 'EPSG:2231' });
+const UNRESOLVED = ctx({ linearUnit: 'unknown', linearUnitToMetres: 1, name: 'local' });
+
+// One geometry, expressed twice: absolute source corners for the streaming
+// header, and the same corners as a local residual plus the origin the loader
+// subtracted for the static cloud. The two frames are deliberately identical so
+// the precision figures are comparable rather than merely similar.
+const ORIGIN: [number, number, number] = [1000, 2000, 30];
+const MIN: [number, number, number] = [1000, 2000, 30];
+const MAX: [number, number, number] = [2000, 3000, 130];
+const SOURCE_POINTS = 1_000_000;
+
+type ReportCloud = StreamingStructureSource & {
+  readonly metadata?: {
+    readonly header?: { min: readonly [number, number, number]; max: readonly [number, number, number] };
+    readonly info?: { spacing?: number };
+    readonly captureSensor?: string;
+    readonly sourceSoftware?: string;
+    readonly captureDate?: string;
+  };
+};
+
+function streamingCloud(over: Partial<ReportCloud> = {}): ReportCloud {
+  return {
+    renderOrigin: ORIGIN,
+    metadata: { header: { min: MIN, max: MAX }, info: { spacing: 2.5 } },
+    maxDepth: () => 5,
+    octree: { nodes: () => [1, 2, 3] },
+    ...over,
+  };
+}
+
+/** The whole streaming report, assembled the way the shell assembles it. */
+function streamingRowsFor(cloud: ReportCloud, frame: SpatialContext): AnalysisRow[] {
+  const rows: AnalysisRow[] = [streamingReportBasisRow()];
+  const header = cloud.metadata?.header;
+  if (header) {
+    const ext = streamingExtentRows(header, frame, SOURCE_POINTS);
+    if (!ext.unitConfirmed) {
+      rows.push({
+        label: 'Units',
+        value: 'unconfirmed — source CRS declares no linear unit; extents shown in source units',
+        status: 'warn',
+      });
+    }
+    for (const r of ext.rows) rows.push({ label: r.label, value: r.value, status: 'info' });
+  }
+  rows.push(...streamingStructureRows(cloud, frame));
+  rows.push(...streamingProvenanceRows(cloud.metadata));
+  return rows;
+}
+
+function staticCloud(metadata?: CloudMetadata): PointCloud {
+  return new PointCloud({
+    positions: new Float32Array([0, 0, 0, 1000, 1000, 100]),
+    origin: ORIGIN,
+    sourceFormat: 'laz',
+    name: 'parity.laz',
+    ...(metadata ? { metadata } : {}),
+  });
+}
+
+const valueOf = (rows: readonly AnalysisRow[], label: string): string | undefined =>
+  rows.find((r) => r.label === label)?.value;
+
+describe('streaming octree spacing carries the unit it earned', () => {
+  test('metre CRS: the source figure is metres and says so', () => {
+    expect(valueOf(streamingStructureRows(streamingCloud(), METRE), 'Octree root spacing'))
+      .toBe('2.50 m');
+  });
+
+  test('foot CRS: 2.5 source units is 0.76 m, never "2.50 m"', () => {
+    const v = valueOf(streamingStructureRows(streamingCloud(), FOOT), 'Octree root spacing');
+    expect(v).not.toBe('2.50 m');
+    expect(v).toBe('0.76 m');
+  });
+
+  test('unresolved unit: the figure stays in source units', () => {
+    expect(valueOf(streamingStructureRows(streamingCloud(), UNRESOLVED), 'Octree root spacing'))
+      .toBe('2.50 (source units)');
+  });
+});
+
+test('unresolved unit: no metric label is fabricated anywhere in the report', () => {
+  const rows = streamingRowsFor(streamingCloud(), UNRESOLVED);
+  expect(rows.length).toBeGreaterThan(5);
+  for (const r of rows) {
+    expect(r.value).not.toMatch(/\d\s*(?:mm|cm|km|m)\b/);
+    expect(r.value).not.toMatch(/pts\/m²/);
+  }
+});
+
+describe('provenance labels match the static report word for word', () => {
+  const declared = {
+    captureSensor: 'Quantum Spatial',
+    sourceSoftware: 'PDAL 2.6.0',
+    captureDate: 'Jan 12, 2021',
+  };
+  const streamingRows = streamingProvenanceRows(declared);
+  const staticRows = scanReport.run(staticCloud(declared), undefined, { spatialContext: METRE }).rows;
+
+  test('LAS system_identifier is "System identifier" on both sides', () => {
+    expect(valueOf(staticRows, 'System identifier')).toBe('Quantum Spatial');
+    expect(valueOf(streamingRows, 'System identifier')).toBe('Quantum Spatial');
+    expect(streamingRows.find((r) => r.label === 'Capture Sensor')).toBeUndefined();
+  });
+
+  test('the header creation date is "File created" on both sides, never "Captured"', () => {
+    expect(valueOf(staticRows, 'File created')).toBe('Jan 12, 2021');
+    expect(valueOf(streamingRows, 'File created')).toBe('Jan 12, 2021');
+    expect(streamingRows.find((r) => r.label === 'Captured')).toBeUndefined();
+    expect(staticRows.find((r) => r.label === 'Captured')).toBeUndefined();
+  });
+});
+
+describe('in-memory precision is one measurement, reported twice', () => {
+  const streamingRows = streamingStructureRows(streamingCloud(), METRE);
+  const staticRows = scanReport.run(staticCloud(), undefined, { spatialContext: METRE }).rows;
+
+  test('the same frame and bounds produce the same canonical figures', () => {
+    expect(valueOf(streamingRows, 'In-memory resolution'))
+      .toBe(valueOf(staticRows, 'In-memory resolution'));
+    expect(valueOf(streamingRows, 'Quantization basis'))
+      .toBe(valueOf(staticRows, 'Quantization basis'));
+  });
+
+  test('the row describes the representation, not the survey', () => {
+    const v = valueOf(streamingRows, 'In-memory resolution') ?? '';
+    expect(v).toContain('worst case');
+    expect(v).toContain('mean over the reach');
+    expect(v).not.toMatch(/accuracy/i);
+  });
+
+  test('a source with no render origin gets no precision row rather than a guess', () => {
+    const rows = streamingStructureRows(streamingCloud({ renderOrigin: undefined }), METRE);
+    expect(rows.find((r) => r.label === 'In-memory resolution')).toBeUndefined();
+    expect(rows.find((r) => r.label === 'Quantization basis')).toBeUndefined();
+  });
+
+  test('the octree ROOT CUBE is not what the reach is taken from', () => {
+    // A cube 10x the data extent must not change the figure: the tight header
+    // box is read first, and the cube is only the unreadable-box fallback.
+    const wide = streamingCloud({ localBounds: () => [-5000, -5000, -5000, 5000, 5000, 5000] });
+    expect(valueOf(streamingStructureRows(wide, METRE), 'In-memory resolution'))
+      .toBe(valueOf(streamingRows, 'In-memory resolution'));
+  });
+});
+
+test('equivalent geometry reports equivalent metric units on both sides', () => {
+  const streamingRows = streamingRowsFor(streamingCloud(), METRE);
+  const staticRows = scanReport.run(staticCloud(), undefined, { spatialContext: METRE }).rows;
+  for (const label of ['Width', 'Depth', 'Height']) {
+    expect(valueOf(streamingRows, label)).toBe(valueOf(staticRows, label));
+  }
+  expect(valueOf(streamingRows, 'Density')).toMatch(/ pts\/m²$/);
+  expect(valueOf(staticRows, 'Density')).toMatch(/ pts\/m²$/);
+});
+
+test('the report states whether its figures are declared or resident', () => {
+  const basis = streamingReportBasisRow();
+  expect(basis.label).toBe('Report basis');
+  expect(basis.value).toContain('hierarchy index');
+  expect(basis.value).toContain('resident');
+});

--- a/tests/streamingSpacingLabel.test.ts
+++ b/tests/streamingSpacingLabel.test.ts
@@ -78,3 +78,13 @@ test('undefined format is treated as COPC and still gates on the unit', () => {
   expect(spacingRowFor(undefined, 0.5, METRE).value).toBe('0.50 m');
   expect(spacingRowFor(undefined, 0.5, UNKNOWN).value).toBe('0.50 (source units)');
 });
+
+test('COPC + foot CRS with no usable metre factor: FAILS CLOSED, never "m"', () => {
+  // The conversion cannot run, and the unconverted number is feet: labelling it
+  // metres would overstate the spacing ~3.28x, the very drift this row gates.
+  for (const factor of [undefined, Number.NaN, Number.POSITIVE_INFINITY, 0, -1]) {
+    const r = spacingRowFor('copc', 4, { linearUnit: 'foot', linearUnitToMetres: factor, isGeographic: false });
+    expect(r.value).toBe('4.00 (source units)');
+    expect(r.value).not.toMatch(/\bm\b/);
+  }
+});


### PR DESCRIPTION
The streaming Scan Report stamped a literal `m` on octree root spacing whatever the source CRS declared, and still called LAS `system_identifier` "Capture Sensor" after the static report was corrected to "System identifier". The comment above it claimed both reports showed the same fields.

Spacing now goes through the existing `spacingRowFor` with the resolved spatial context: metres print metres, a foot CRS converts, a geographic CRS says spacing is not a linear distance, and an unresolved unit prints source units. A foot CRS whose metre factor is missing or non-finite previously rendered `NaN m`; it now fails closed.

The report gains a `File created` row and the canonical in-memory precision sentence, both reusing the static modules so the two paths print identical strings, fed the tight header bounds rather than the octree cube.
