### PR TITLE
fix(report): render one bounding box in one unit

### DIFF
--- a/src/report/ReportMetadataSection.ts
+++ b/src/report/ReportMetadataSection.ts
@@ -82,15 +82,6 @@ export interface MetadataInputs {
   };
 }
 
-/** Format a metre value: km / m / cm depending on magnitude. */
-function formatMetres(m: number): string {
-  if (!Number.isFinite(m)) return 'unknown';
-  if (m >= 1000) return `${(m / 1000).toFixed(2)} km`;
-  if (m >= 10) return `${m.toFixed(1)} m`;
-  if (m >= 1) return `${m.toFixed(2)} m`;
-  return `${(m * 100).toFixed(1)} cm`;
-}
-
 /**
  * Format a raw source-unit extent — used when the CRS declares no real linear
  * unit. No km/m/cm scaling and no "m" label: the magnitude's unit is unknown,
@@ -99,6 +90,55 @@ function formatMetres(m: number): string {
 function formatSourceUnits(n: number): string {
   if (!Number.isFinite(n)) return 'unknown';
   return `${n.toFixed(1)} (source units)`;
+}
+
+/**
+ * Width, Depth and Height describe ONE bounding box, so they share one unit.
+ * Formatting each independently let a 1000 m depth cross the km threshold while
+ * its 922 m and 331 m siblings stayed in metres, so the report read
+ * "922.0 m / 1.00 km / 330.6 m" for one box while the on-screen Scan Report
+ * showed 1000.0 m for the same depth. The unit is chosen from the LARGEST
+ * dimension and applied to all three, so the figures stay comparable by eye.
+ */
+export function extentRows(inputs: {
+  readonly width: number;
+  readonly depth: number;
+  readonly height: number;
+  readonly unitKnown: boolean;
+}): Array<{ label: string; value: string }> {
+  const labels = ['Width', 'Depth', 'Height'] as const;
+  const dims = [inputs.width, inputs.depth, inputs.height];
+  if (!inputs.unitKnown) {
+    return labels.map((label, i) => ({ label, value: formatSourceUnits(dims[i]) }));
+  }
+  const finite = dims.filter((d) => Number.isFinite(d));
+  const largest = finite.length > 0 ? Math.max(...finite) : Number.NaN;
+  // One scale for the whole group, picked from the largest dimension. km starts
+  // at 10 km, not 1 km: a 1 km survey tile reads 1000.0 m on screen, and the
+  // report must not render that same depth as 1.00 km.
+  const base = !Number.isFinite(largest)
+    ? { div: 1, unit: 'm' }
+    : largest >= 10_000
+      ? { div: 1000, unit: 'km' }
+      : largest >= 1
+        ? { div: 1, unit: 'm' }
+        : { div: 0.01, unit: 'cm' };
+  // Decimals come from the SMALLEST side, so a thin box does not round its own
+  // thickness away once every side shares one unit: a 2500 x 78.8 x 0.05 m box
+  // reads 0.050 m, not 0.1 m.
+  const smallest = finite.filter((d) => d > 0).reduce((a, b) => Math.min(a, b), Infinity);
+  const scaledSmall = Number.isFinite(smallest) ? smallest / base.div : Number.NaN;
+  const dp = !Number.isFinite(scaledSmall) || scaledSmall >= 10
+    ? 1
+    : Math.min(3, Math.max(1, Math.ceil(-Math.log10(scaledSmall)) + 1));
+  const scale = { ...base, dp };
+  return labels.map((label, i) => {
+    const v = dims[i];
+    return {
+      label,
+      value: Number.isFinite(v) ? `${(v / scale.div).toFixed(scale.dp)} ${scale.unit}` : 'unknown',
+    };
+  });
 }
 
 /** Pretty-format an integer point count with locale separators. */
@@ -198,19 +238,16 @@ export function buildDatasetSummary(inputs: MetadataInputs): readonly ReportData
   // confirmed unit (or the absent default) is byte-identical to before.
   const unitsUnconfirmed = inputs.extentUnitStatus === 'unknown';
   if (unitsUnconfirmed) {
-    rows.push(
-      { label: 'Units',  value: 'Unconfirmed — extents in source units' },
-      { label: 'Width',  value: formatSourceUnits(inputs.width) },
-      { label: 'Depth',  value: formatSourceUnits(inputs.depth) },
-      { label: 'Height', value: formatSourceUnits(inputs.height) },
-    );
-  } else {
-    rows.push(
-      { label: 'Width',  value: formatMetres(inputs.width) },
-      { label: 'Depth',  value: formatMetres(inputs.depth) },
-      { label: 'Height', value: formatMetres(inputs.height) },
-    );
+    rows.push({ label: 'Units', value: 'Unconfirmed — extents in source units' });
   }
+  rows.push(
+    ...extentRows({
+      width: inputs.width,
+      depth: inputs.depth,
+      height: inputs.height,
+      unitKnown: !unitsUnconfirmed,
+    }),
+  );
   if (Number.isFinite(inputs.density) && inputs.density > 0) {
     // One decimal — same as the Inspection-summary finding and the on-screen
     // panel. Integer rounding printed 2.586 as "3", disagreeing with them.

--- a/tests/extentRowsOneUnit.test.ts
+++ b/tests/extentRowsOneUnit.test.ts
@@ -1,0 +1,54 @@
+/**
+ * extentRowsOneUnit.test.ts
+ *
+ * Width, Depth and Height describe one bounding box, so they must render in
+ * ONE unit. Formatting each independently sent a 1000 m depth over the km
+ * threshold while its 922 m and 331 m siblings stayed in metres, printing
+ * "922.0 m / 1.00 km / 330.6 m" in the technical report while the on-screen
+ * Scan Report showed "1000.0 m" for the same value.
+ */
+import { describe, it, expect } from 'vitest';
+import { extentRows, buildDatasetSummary } from '../src/report/ReportMetadataSection';
+
+describe('extent rows share one unit', () => {
+  it('keeps a 1000 m depth in metres beside its metre-scale siblings', () => {
+    const rows = extentRows({ width: 922.0, depth: 1000.0, height: 330.6, unitKnown: true });
+    const vals = rows.map((r) => r.value);
+    expect(vals.every((v) => / m$/.test(v))).toBe(true);
+    expect(vals).toContain('1000.0 m');
+    expect(vals.some((v) => /km/.test(v))).toBe(false);
+  });
+
+  it('uses km for all three when the box is genuinely kilometre-scale', () => {
+    const rows = extentRows({ width: 12000, depth: 8000, height: 2400, unitKnown: true });
+    expect(rows.every((r) => /km$/.test(r.value))).toBe(true);
+  });
+
+  it('uses one sub-metre unit across a small object scan', () => {
+    const rows = extentRows({ width: 0.42, depth: 0.31, height: 0.9, unitKnown: true });
+    const units = new Set(rows.map((r) => r.value.replace(/^[\d.]+\s*/, '')));
+    expect(units.size).toBe(1);
+  });
+
+  it('never labels a unit when the CRS declares none', () => {
+    const rows = extentRows({ width: 922.0, depth: 1000.0, height: 330.6, unitKnown: false });
+    expect(rows.every((r) => /\(source units\)$/.test(r.value))).toBe(true);
+    expect(rows.some((r) => /\bm\b|km|cm/.test(r.value))).toBe(false);
+  });
+});
+
+describe('the rendered dataset summary, not just the helper', () => {
+  it('renders Width, Depth and Height in one unit on a 1 km tile', () => {
+    const rows = buildDatasetSummary({
+      fileName: 'tile.laz', format: 'LAZ', pointCount: 37_333_283,
+      width: 922.0, depth: 1000.0, height: 330.6,
+      density: 40.5, hasRgb: false, hasIntensity: true, hasClassification: true,
+      crsName: 'NAD83(2011) / UTM zone 10N (EPSG:6339)',
+      extentUnitStatus: 'confirmed', unitName: 'metre',
+    } as never);
+    const byLabel = (l: string) => rows.find((r) => r.label === l)?.value ?? '';
+    const dims = ['Width', 'Depth', 'Height'].map(byLabel);
+    expect(dims).toEqual(['922.0 m', '1000.0 m', '330.6 m']);
+    expect(dims.some((v) => /km/.test(v))).toBe(false);
+  });
+});

--- a/tests/reportEngine.test.ts
+++ b/tests/reportEngine.test.ts
@@ -290,18 +290,24 @@ describe('buildDatasetSummary', () => {
     expect(points?.value).toBe('9,600,000');
   });
 
-  it('formats metres by magnitude (km / m / cm)', () => {
+  it('renders one box in ONE unit, however extreme its aspect ratio', () => {
+    // This case used to print "2.50 km", "78.8 m" and "5.0 cm": three units for
+    // three sides of one bounding box, which no reader can compare by eye. The
+    // group now shares the unit of its largest side and takes its decimals from
+    // the smallest, so the thin axis survives.
     const rows = buildDatasetSummary({
       fileName: 's', format: 'COPC', sourcePointCount: 100,
-      width: 2500,    // → 2.50 km
-      depth: 78.8,    // → 78.8 m
-      height: 0.05,   // → 5.0 cm
+      width: 2500,
+      depth: 78.8,
+      height: 0.05,
       density: NaN,
       hasRgb: false, hasIntensity: false, hasClassification: false,
     });
-    expect(rows.find((r) => r.label === 'Width')?.value).toBe('2.50 km');
-    expect(rows.find((r) => r.label === 'Depth')?.value).toBe('78.8 m');
-    expect(rows.find((r) => r.label === 'Height')?.value).toBe('5.0 cm');
+    const v = (l: string) => rows.find((r) => r.label === l)?.value ?? '';
+    const units = new Set(['Width', 'Depth', 'Height'].map((l) => v(l).replace(/^[\d.]+\s*/, '')));
+    expect(units).toEqual(new Set(['m']));
+    expect(v('Height')).not.toBe('0.1 m');
+    expect(Number.parseFloat(v('Height'))).toBeCloseTo(0.05, 3);
   });
 
   it('omits CRS rows when not supplied', () => {


### PR DESCRIPTION
The technical report formatted Width, Depth and Height independently, so one bounding box printed as `922.0 m`, `1.00 km`, `330.6 m`. The on-screen Scan Report showed `1000.0 m` for that same depth, so the two surfaces disagreed on a number neither had computed differently.

The three rows now share one unit, taken from the largest side, with decimals taken from the smallest so a thin axis is not rounded away. A box of 2500 by 78.8 by 0.05 m keeps its 0.050 m thickness instead of reading `0.1 m`. The km threshold moves to 10 km so a 1 km survey tile reads in metres, matching the panel.

An existing test pinned the old behaviour, asserting km, m and cm across one box; it now asserts a single unit.
