### PR TITLE
fix(report): stop the space report claiming units it disclaims

### DIFF
--- a/src/terrain/space/spaceReportLayout.ts
+++ b/src/terrain/space/spaceReportLayout.ts
@@ -14,19 +14,24 @@
  * HONESTY: every figure comes straight from {@link SpaceMetrics} /
  * {@link ObjectMetrics}; absent values read as an em-dash, never a fabricated
  * zero. The not-survey-grade note and the panel's caveats are carried verbatim.
+ *
+ * UNITS: the row formatters are selected from the RESOLVED linear-unit scale,
+ * so the report cannot disclaim the scale in its provenance and stamp a metre
+ * suffix on its rows at the same time. An unverified scale prints bare numbers
+ * qualified as source units, with no foot conversion.
  */
 
 import type { SpaceMetrics } from '../spaceMetrics';
-import { metresToFeet, sqMetresToSqFeet, cubicMetresToCubicFeet } from '../spaceMetrics';
+import {
+  metresToFeet,
+  sqMetresToSqFeet,
+  cubicMetresToCubicFeet,
+  resolveLinearUnitScale,
+} from '../spaceMetrics';
 import type { ObjectMetrics } from '../objectMetrics';
 import { SOFTWARE_NAME, NOT_SURVEY_GRADE_NOTE } from '../export/exportProvenance';
 import { evidenceNote } from '../../validation/exportEvidenceNote';
-import {
-  type LinearUnitScale,
-  knownUnit,
-  unknownUnit,
-  UNIT_FACTORS,
-} from '../../units/units';
+import { type LinearUnitScale, UNIT_FACTORS } from '../../units/units';
 
 /** One label/value line in a report section. */
 export interface ReportRow {
@@ -51,8 +56,14 @@ export interface SpaceReportProvenance {
   readonly scanType: string;
   /** 'metres' / 'feet (source) → metres' etc. */
   readonly units: string;
-  readonly sampledPointCount: number;
-  readonly sourcePointCount: number;
+  /** Points actually measured (the subset the metrics were computed over). */
+  readonly measuredPointCount: number;
+  /**
+   * The LOADED / resident population that subset was drawn from. Never the
+   * file's declared total: a display-sampled or still-streaming load holds far
+   * fewer points than the file, so this must not be printed as "source".
+   */
+  readonly loadedPointCount: number;
   readonly notSurveyGrade: string;
 }
 
@@ -83,47 +94,113 @@ export interface SpaceReportInput {
   /**
    * Legacy source-unit→metre factor (from the CRS). AMBIGUOUS at exactly 1: a
    * genuine metre CRS and an unknown / local scan BOTH arrive as 1, so this
-   * number alone cannot honestly assert metres. Prefer {@link linearUnit}, which
-   * carries the known/unknown distinction; a bare factor of 1 is read as an
-   * UNKNOWN scale (no metre claim) rather than the old "metres (assumed)".
+   * number alone cannot honestly assert metres. It is the LAST resort: the
+   * scale on {@link space} (resolved from the CRS authority) and an explicit
+   * {@link linearUnit} both outrank it, and a bare factor of 1 is read as an
+   * UNKNOWN scale rather than the old "metres (assumed)".
    */
   readonly unitToMetres?: number;
   /**
    * The source frame's linear-unit scale as a discriminated union, so an unknown
    * unit can never be silently labelled metres. When supplied this WINS over
-   * {@link unitToMetres}: `knownUnit(1)` prints "metres", a foot factor prints
-   * the feet→metres conversion, and `unknownUnit()` states the coordinates are
-   * in the file's own (unverified) units.
+   * both `space.linearUnit` and {@link unitToMetres}: `knownUnit(1)` prints
+   * "metres", a foot factor prints the feet→metres conversion, and
+   * `unknownUnit()` states the coordinates are in the file's own units.
+   *
+   * Normally unnecessary: `space.linearUnit` already carries the authoritative
+   * verdict, because `spaceMetrics` records the `unitKnown` flag the caller took
+   * from the resolved `SpatialContext`.
    */
   readonly linearUnit?: LinearUnitScale;
 }
 
 const DASH = '—';
-const m1 = (v: number | null | undefined): string =>
-  v != null && Number.isFinite(v) ? v.toFixed(2) : DASH;
-const i0 = (v: number | null | undefined): string =>
-  v != null && Number.isFinite(v) ? Math.round(v).toLocaleString() : DASH;
-/** "12.3 m (40.4 ft)". */
-const mft = (v: number | null | undefined): string =>
-  v != null && Number.isFinite(v) ? `${v.toFixed(1)} m (${metresToFeet(v).toFixed(1)} ft)` : DASH;
-const areaMft = (v: number | null | undefined): string =>
-  v != null && Number.isFinite(v)
-    ? `${Math.round(v).toLocaleString()} m² (${Math.round(sqMetresToSqFeet(v)).toLocaleString()} ft²)`
-    : DASH;
-const volMft = (v: number | null | undefined): string =>
-  v != null && Number.isFinite(v)
-    ? `${Math.round(v).toLocaleString()} m³ (${Math.round(cubicMetresToCubicFeet(v)).toLocaleString()} ft³)`
-    : DASH;
-const areaMftFine = (v: number | null | undefined): string =>
-  v != null && Number.isFinite(v)
-    ? `${v.toFixed(2)} m² (${sqMetresToSqFeet(v).toFixed(1)} ft²)`
-    : DASH;
-const volMftFine = (v: number | null | undefined): string =>
-  v != null && Number.isFinite(v)
-    ? `${v.toFixed(2)} m³ (${cubicMetresToCubicFeet(v).toFixed(1)} ft³)`
-    : DASH;
-const cm = (v: number | null | undefined): string =>
-  v != null && Number.isFinite(v) ? `${(v * 100).toFixed(1)} cm` : DASH;
+type Num = number | null | undefined;
+const ok = (v: Num): v is number => v != null && Number.isFinite(v);
+const m1 = (v: Num): string => (ok(v) ? v.toFixed(2) : DASH);
+const i0 = (v: Num): string => (ok(v) ? Math.round(v).toLocaleString() : DASH);
+
+// Source-unit qualifiers for the UNKNOWN-scale branch. They name the number's
+// dimensionality without asserting a metre, so the row is still readable.
+const SU = '(source units)';
+const SU_SQ = '(square source units)';
+const SU_CU = '(cubic source units)';
+
+/**
+ * The value formatters for one report, bound ONCE to the resolved scale.
+ *
+ * This is the seam the field defect went through: the row builders used to call
+ * hard-coded ` m` / `metresToFeet(...)` helpers that never saw the scale, so a
+ * report whose provenance said "scale unverified" still stamped metres on every
+ * length and converted them to feet on top. With the formatters chosen from the
+ * scale, an unverified unit CANNOT reach a metre suffix.
+ *
+ * Only the suffix and the presence of the conversion differ between the two
+ * branches; the numbers are identical.
+ */
+interface UnitFormat {
+  /** L x W x H with the foot conversion (the wide dimension rows). */
+  readonly triple: (l: number, w: number, h: number) => string;
+  /** L x W x H without a conversion (the axis-aligned row). */
+  readonly tripleBare: (l: number, w: number, h: number) => string;
+  /** A single length. */
+  readonly len: (v: Num) => string;
+  /** A coarse (rounded) area. */
+  readonly area: (v: Num) => string;
+  /** A coarse (rounded) volume. */
+  readonly vol: (v: Num) => string;
+  /** A fine (2 dp) area. */
+  readonly areaFine: (v: Num) => string;
+  /** A fine (2 dp) volume. */
+  readonly volFine: (v: Num) => string;
+  /** Mean point spacing. */
+  readonly spacing: (v: Num) => string;
+  /** Areal point density. */
+  readonly density: (v: Num) => string;
+}
+
+/** Metric branch: the exact strings the report has always printed. */
+const METRIC_FORMAT: UnitFormat = {
+  triple: (l, w, h) =>
+    `${m1(l)} x ${m1(w)} x ${m1(h)} m  (${metresToFeet(l).toFixed(1)} x ` +
+    `${metresToFeet(w).toFixed(1)} x ${metresToFeet(h).toFixed(1)} ft)`,
+  tripleBare: (l, w, h) => `${m1(l)} x ${m1(w)} x ${m1(h)} m`,
+  len: (v) => (ok(v) ? `${v.toFixed(1)} m (${metresToFeet(v).toFixed(1)} ft)` : DASH),
+  area: (v) =>
+    ok(v)
+      ? `${Math.round(v).toLocaleString()} m² (${Math.round(sqMetresToSqFeet(v)).toLocaleString()} ft²)`
+      : DASH,
+  vol: (v) =>
+    ok(v)
+      ? `${Math.round(v).toLocaleString()} m³ (${Math.round(cubicMetresToCubicFeet(v)).toLocaleString()} ft³)`
+      : DASH,
+  areaFine: (v) => (ok(v) ? `${v.toFixed(2)} m² (${sqMetresToSqFeet(v).toFixed(1)} ft²)` : DASH),
+  volFine: (v) => (ok(v) ? `${v.toFixed(2)} m³ (${cubicMetresToCubicFeet(v).toFixed(1)} ft³)` : DASH),
+  spacing: (v) => (ok(v) ? `${(v * 100).toFixed(1)} cm` : DASH),
+  density: (v) => (ok(v) ? `${v.toFixed(1)} pts/m²` : DASH),
+};
+
+/**
+ * Unknown branch: the SAME numbers with no metre suffix and no foot conversion.
+ * Converting an unverified unit to feet would be a second fabrication stacked on
+ * the first, so the conversion is dropped outright rather than relabelled. Mean
+ * spacing loses its x100 centimetre rendering for the same reason: a centimetre
+ * is a metre subdivision, and the scale is not known to be metres.
+ */
+const SOURCE_FORMAT: UnitFormat = {
+  triple: (l, w, h) => `${m1(l)} x ${m1(w)} x ${m1(h)}  ${SU}`,
+  tripleBare: (l, w, h) => `${m1(l)} x ${m1(w)} x ${m1(h)}  ${SU}`,
+  len: (v) => (ok(v) ? `${v.toFixed(1)} ${SU}` : DASH),
+  area: (v) => (ok(v) ? `${Math.round(v).toLocaleString()} ${SU_SQ}` : DASH),
+  vol: (v) => (ok(v) ? `${Math.round(v).toLocaleString()} ${SU_CU}` : DASH),
+  areaFine: (v) => (ok(v) ? `${v.toFixed(2)} ${SU_SQ}` : DASH),
+  volFine: (v) => (ok(v) ? `${v.toFixed(2)} ${SU_CU}` : DASH),
+  spacing: (v) => (ok(v) ? `${v.toFixed(3)} ${SU}` : DASH),
+  density: (v) => (ok(v) ? `${v.toFixed(1)} pts per square source unit` : DASH),
+};
+
+const unitFormat = (scale: LinearUnitScale): UnitFormat =>
+  scale.known ? METRIC_FORMAT : SOURCE_FORMAT;
 
 function toIso(at: Date | string | null | undefined): string {
   if (at instanceof Date) return at.toISOString();
@@ -131,14 +208,26 @@ function toIso(at: Date | string | null | undefined): string {
   return new Date().toISOString();
 }
 
-/** Capture-quality section, shared between interior + object reports. */
-function captureSection(q: SpaceMetrics['quality']): ReportSection {
+/**
+ * Capture-quality section, shared between interior + object reports.
+ *
+ * The point row names BOTH populations for what they are. It used to read
+ * "Points (used / source)", but the second number is the LOADED / resident
+ * count the viewer holds, which for a display-sampled or still-streaming cloud
+ * is far smaller than the file's declared total. Calling it "source" invited
+ * the reader to treat a display sample as the whole file. The file total is not
+ * available at this layer, so no file-total claim is printed at all.
+ */
+function captureSection(q: SpaceMetrics['quality'], f: UnitFormat): ReportSection {
   return {
     title: 'Capture quality',
     rows: [
-      { label: 'Points (used / source)', value: `${i0(q.sampledPointCount)} / ${i0(q.sourcePointCount)}` },
-      { label: 'Density', value: `${q.densityPerM2.toFixed(1)} pts/m²` },
-      { label: 'Mean spacing', value: cm(q.meanSpacingM) },
+      {
+        label: 'Points (measured / loaded)',
+        value: `${i0(q.sampledPointCount)} measured / ${i0(q.sourcePointCount)} loaded`,
+      },
+      { label: 'Density', value: f.density(q.densityPerM2) },
+      { label: 'Mean spacing', value: f.spacing(q.meanSpacingM) },
       // HONESTY: coveragePct is occupied / (cols*rows) over the bounding-box
       // grid — a fill ratio of the extent, not a traced footprint. Label says so
       // (matches the ObjectPanel "Bounding area filled" row).
@@ -171,87 +260,87 @@ function unitsLabel(scale: LinearUnitScale): string {
 }
 
 /**
- * Bridge the legacy bare `unitToMetres` number to a discriminated scale. A
- * factor of exactly 1 is AMBIGUOUS (a genuine metre CRS and an unknown / local
- * scan both arrive as 1), so it is read as UNKNOWN — the conservative, honest
- * reading that never fabricates a metre claim. A finite non-unit factor was
- * supplied deliberately from a KNOWN linear unit, so it is a known scale.
+ * The scale this report prints under, in authority order:
+ *
+ * 1. an explicit {@link SpaceReportInput.linearUnit};
+ * 2. the scale the metrics were COMPUTED under, which the CRS authority
+ *    resolved (`SpatialContext.linearUnitKnown` reaches `spaceMetrics` as
+ *    `unitKnown` and is recorded on the result). This is how a declared metre
+ *    CRS stops being read as unknown: the factor is 1 either way, but the
+ *    authority knows which 1 it is;
+ * 3. the legacy bare factor, which cannot tell the two apart and so fails
+ *    closed to unknown at exactly 1.
+ *
+ * Order 2 before 3 deliberately: a metrics object that says the unit is
+ * unverified must not be overridden by a bare factor supplied alongside it.
  */
-function scaleFromFactor(unitToMetres: number | undefined): LinearUnitScale {
-  if (
-    unitToMetres != null &&
-    Number.isFinite(unitToMetres) &&
-    unitToMetres > 0 &&
-    unitToMetres !== 1
-  ) {
-    return knownUnit(unitToMetres);
-  }
-  return unknownUnit();
+function reportScale(input: SpaceReportInput): LinearUnitScale {
+  return (
+    input.linearUnit ??
+    input.space?.linearUnit ??
+    resolveLinearUnitScale(input.unitToMetres, undefined)
+  );
 }
 
 /**
  * Build the pure content model for the INTERIOR report from space metrics.
  */
-function interiorContent(input: SpaceReportInput): SpaceReportContent {
+function interiorContent(input: SpaceReportInput, scale: LinearUnitScale): SpaceReportContent {
   const space = input.space!;
   const d = space.dims;
   const p = space.planes;
+  const f = unitFormat(scale);
   const dims: ReportSection = {
     title: 'Dimensions',
     rows: [
-      {
-        label: 'L x W x H',
-        value: `${m1(d.lengthM)} x ${m1(d.widthM)} x ${m1(d.heightM)} m  (${metresToFeet(d.lengthM).toFixed(1)} x ${metresToFeet(d.widthM).toFixed(1)} x ${metresToFeet(d.heightM).toFixed(1)} ft)`,
-      },
-      { label: 'Floor area', value: areaMft(space.floorAreaM2) },
-      { label: 'Ceiling height', value: mft(space.ceilingHeightM) },
-      { label: 'Enclosed volume', value: volMft(space.enclosedVolumeM3) },
+      { label: 'L x W x H', value: f.triple(d.lengthM, d.widthM, d.heightM) },
+      { label: 'Floor area', value: f.area(space.floorAreaM2) },
+      { label: 'Ceiling height', value: f.len(space.ceilingHeightM) },
+      { label: 'Enclosed volume', value: f.vol(space.enclosedVolumeM3) },
       { label: 'Storeys / levels', value: i0(space.storyCount) },
     ],
   };
   const planes: ReportSection = {
     title: 'Planes',
     rows: [
-      { label: 'Floor', value: p.floorPresent ? `Present  ${areaMft(p.floorAreaM2)}` : 'Not detected' },
-      { label: 'Ceiling', value: p.ceilingPresent ? `Present  ${areaMft(p.ceilingAreaM2)}` : 'Not detected' },
+      { label: 'Floor', value: p.floorPresent ? `Present  ${f.area(p.floorAreaM2)}` : 'Not detected' },
+      { label: 'Ceiling', value: p.ceilingPresent ? `Present  ${f.area(p.ceilingAreaM2)}` : 'Not detected' },
       {
         label: 'Walls',
         value: `${Math.round(p.wallCoveragePct)}% coverage / ~${p.dominantWallDirections} direction(s)`,
       },
     ],
   };
-  return assemble(input, space, 'Interior space', [dims, planes, captureSection(space.quality)]);
+  return assemble(input, space, 'Interior space', [dims, planes, captureSection(space.quality, f)], scale);
 }
 
 /**
  * Build the pure content model for the OBJECT report from object + space metrics
  * (space supplies the capture-quality block + reasons).
  */
-function objectContent(input: SpaceReportInput): SpaceReportContent {
+function objectContent(input: SpaceReportInput, scale: LinearUnitScale): SpaceReportContent {
   const o = input.object!;
   const space = input.space;
   const obb = o.obb;
   const aabb = o.aabb;
+  const f = unitFormat(scale);
   const dims: ReportSection = {
     title: 'Dimensions',
     rows: [
-      {
-        label: 'Oriented (L x W x H)',
-        value: `${m1(obb.lengthM)} x ${m1(obb.widthM)} x ${m1(obb.heightM)} m  (${metresToFeet(obb.lengthM).toFixed(1)} x ${metresToFeet(obb.widthM).toFixed(1)} x ${metresToFeet(obb.heightM).toFixed(1)} ft)`,
-      },
+      { label: 'Oriented (L x W x H)', value: f.triple(obb.lengthM, obb.widthM, obb.heightM) },
       {
         label: 'Axis-aligned (L x W x H)',
-        value: `${m1(aabb.lengthM)} x ${m1(aabb.widthM)} x ${m1(aabb.heightM)} m`,
+        value: f.tripleBare(aabb.lengthM, aabb.widthM, aabb.heightM),
       },
-      { label: 'Largest dimension', value: mft(o.longestDimensionM) },
-      { label: 'Envelope volume', value: volMftFine(o.envelopeVolumeM3) },
-      { label: 'Bounding surface area', value: areaMftFine(o.surfaceAreaM2) },
+      { label: 'Largest dimension', value: f.len(o.longestDimensionM) },
+      { label: 'Envelope volume', value: f.volFine(o.envelopeVolumeM3) },
+      { label: 'Bounding surface area', value: f.areaFine(o.surfaceAreaM2) },
       { label: 'Scan completeness', value: `${Math.round(o.completenessPct)}% of directions` },
     ],
   };
   const sections: ReportSection[] = [dims];
-  if (space) sections.push(captureSection(space.quality));
-  return assemble(input, space, 'Object', sections);
+  if (space) sections.push(captureSection(space.quality, f));
+  return assemble(input, space, 'Object', sections, scale);
 }
 
 /** Common assembly: title, subtitle, provenance, provenance lines, caveats. */
@@ -260,11 +349,9 @@ function assemble(
   space: SpaceMetrics | null,
   scanType: string,
   sections: ReportSection[],
+  scale: LinearUnitScale,
 ): SpaceReportContent {
   const name = (input.name ?? '').trim() || 'Untitled scan';
-  // Prefer the discriminated scale; fall back to the legacy numeric factor,
-  // which reads an ambiguous factor-of-1 as UNKNOWN rather than asserting metres.
-  const scale: LinearUnitScale = input.linearUnit ?? scaleFromFactor(input.unitToMetres);
   const provenance: SpaceReportProvenance = {
     software: SOFTWARE_NAME,
     softwareVersion: input.softwareVersion ?? 'unknown',
@@ -273,8 +360,8 @@ function assemble(
     source: input.name ?? null,
     scanType,
     units: unitsLabel(scale),
-    sampledPointCount: space?.quality.sampledPointCount ?? 0,
-    sourcePointCount: space?.quality.sourcePointCount ?? 0,
+    measuredPointCount: space?.quality.sampledPointCount ?? 0,
+    loadedPointCount: space?.quality.sourcePointCount ?? 0,
     notSurveyGrade: NOT_SURVEY_GRADE_NOTE,
   };
   return {
@@ -300,7 +387,7 @@ export function spaceProvenanceLines(p: SpaceReportProvenance): string[] {
     kv('Source', p.source ?? 'unknown'),
     kv('Scan type', p.scanType),
     kv('Units', p.units),
-    kv('Points', `${i0(p.sampledPointCount)} used / ${i0(p.sourcePointCount)} source`),
+    kv('Points', `${i0(p.measuredPointCount)} measured / ${i0(p.loadedPointCount)} loaded in viewer`),
     kv('Note', p.notSurveyGrade),
     // Route the space/object report through the ONE evidence gate (PR6): its
     // dimensional figures sit below their required level, so the report states
@@ -315,13 +402,18 @@ export function spaceProvenanceLines(p: SpaceReportProvenance): string[] {
  * yet) it returns a graceful, near-empty report rather than throwing.
  */
 export function buildSpaceReportContent(input: SpaceReportInput): SpaceReportContent {
+  const scale = reportScale(input);
   if (!input.space) {
-    return assemble(input, null, input.object ? 'Object' : 'Interior space', [
-      { title: 'Measurements', rows: [{ label: 'Status', value: 'No measurements available yet.' }] },
-    ]);
+    return assemble(
+      input,
+      null,
+      input.object ? 'Object' : 'Interior space',
+      [{ title: 'Measurements', rows: [{ label: 'Status', value: 'No measurements available yet.' }] }],
+      scale,
+    );
   }
   if (input.space.spaceKind === 'object' || input.object) {
-    return objectContent(input);
+    return objectContent(input, scale);
   }
-  return interiorContent(input);
+  return interiorContent(input, scale);
 }

--- a/src/terrain/spaceMetrics.ts
+++ b/src/terrain/spaceMetrics.ts
@@ -22,6 +22,7 @@
 
 import { footprintRect, type Axis } from './scanShape';
 import { objectMetrics } from './objectMetrics';
+import { type LinearUnitScale, knownUnit, unknownUnit } from '../units/units';
 import { denseFootprintBbox } from './space/floorplan/wallSlice';
 
 /** Exact metre→foot factor (1 ft = 0.3048 m). */
@@ -62,11 +63,16 @@ export interface PlaneReport {
 export interface CaptureQuality {
   /** Points actually used (after striding to the sample budget). */
   readonly sampledPointCount: number;
-  /** Source / resident point count the sample was drawn from. */
+  /**
+   * The LOADED / resident population the measured subset was drawn from. This
+   * is what the viewer holds, NOT the file's declared point total: a
+   * display-sampled load or a partially streamed cloud both report the resident
+   * count here, so no consumer may label it "source" or "the full scan".
+   */
   readonly sourcePointCount: number;
   /**
-   * Points per m² of occupied footprint, describing the SCAN: the sampled
-   * count is scaled back up by the known stride (sourcePointCount /
+   * Points per m² of occupied footprint, describing the LOADED sample: the
+   * measured count is scaled back up by the known stride (sourcePointCount /
    * sampledPointCount — uniform striding, so the ratio IS the stride). The
    * pre-v0.4.5 figure divided only the sample by the area, under-reporting
    * density by the stride factor (100× at stride 100).
@@ -94,8 +100,40 @@ export interface SpaceMetrics {
   /** Storey / level count from well-separated floor peaks (≥ ~2.2 m apart). */
   readonly storyCount: number;
   readonly quality: CaptureQuality;
+  /**
+   * The AUTHORITATIVE source-unit scale these figures were computed under,
+   * carried on the result so every consumer (panel, report, PDF) reads the same
+   * known/unknown verdict instead of guessing it from the factor's value. A
+   * factor of 1 alone cannot tell a declared metre CRS from an unknown scan;
+   * `SpaceMetricsParams.unitKnown` can, and it is resolved here once.
+   */
+  readonly linearUnit: LinearUnitScale;
   /** Honesty caveats + basis strings. */
   readonly reasons: readonly string[];
+}
+
+/**
+ * Resolve the source frame's linear-unit scale from the CRS-authority flag,
+ * falling back to the legacy bare factor for callers that predate the flag.
+ *
+ * `unitKnown === true` is the CRS authority speaking, so a factor of exactly 1
+ * is a DECLARED metre CRS and prints metres. `unitKnown === false` is an
+ * explicit "not resolved" and is always unknown. When the flag is absent the
+ * legacy bridge applies: a finite non-unit factor was supplied deliberately
+ * from a known linear unit, while a bare 1 is ambiguous and fails closed to
+ * unknown rather than fabricating a metre claim.
+ */
+export function resolveLinearUnitScale(
+  unitToMetres: number | undefined,
+  unitKnown: boolean | undefined,
+): LinearUnitScale {
+  const usable =
+    unitToMetres != null && Number.isFinite(unitToMetres) && unitToMetres > 0
+      ? unitToMetres
+      : null;
+  if (unitKnown === true) return knownUnit(usable ?? 1);
+  if (unitKnown === false) return unknownUnit();
+  return usable != null && usable !== 1 ? knownUnit(usable) : unknownUnit();
 }
 
 export interface SpaceMetricsParams {
@@ -119,7 +157,7 @@ export interface SpaceMetricsParams {
   readonly unitKnown?: boolean;
   /** Whether the scan carries colour. */
   readonly hasRgb?: boolean;
-  /** Honest source/resident count the sample was drawn from. */
+  /** Honest loaded/resident count the measured subset was drawn from. */
   readonly sourcePointCount?: number;
   /**
    * True when the analysed points are the resident subset of a still-streaming
@@ -251,6 +289,8 @@ export function spaceMetrics(
   const n = Math.floor(positions.length / 3);
   const sourcePointCount = params.sourcePointCount ?? n;
 
+  const linearUnit = resolveLinearUnitScale(params.unitToMetres, params.unitKnown);
+
   const reasons: string[] = [params.residentOnly ? PARTIAL_STREAM_CAVEAT : STREAM_CAVEAT];
   // Fail closed on an unverified scale: when the caller knows the linear unit is
   // NOT resolved, every metre figure below is an assume-metres default, so
@@ -267,7 +307,7 @@ export function spaceMetrics(
     dims: { lengthM: 0, widthM: 0, heightM: 0 },
     floorAreaM2: 0, ceilingHeightM: null, enclosedVolumeM3: null,
     planes: { floorPresent: false, floorAreaM2: null, ceilingPresent: false, ceilingAreaM2: null, wallCoveragePct: 0, dominantWallDirections: 0 },
-    storyCount: 0, quality: blankQuality,
+    storyCount: 0, quality: blankQuality, linearUnit,
     reasons: [...reasons, 'Too few points to measure this space yet.'],
   };
   if (n < 16) return blank;
@@ -545,8 +585,10 @@ export function spaceMetrics(
   };
   if (sampleScale > 1) {
     reasons.push(
-      `Density and spacing are scaled from a ${m.toLocaleString()}-point sample to the full ` +
-        `${sourcePointCount.toLocaleString()}-point scan (uniform-stride assumption).`,
+      `Density and spacing are scaled from a ${m.toLocaleString()}-point measured subset ` +
+        `to the ${sourcePointCount.toLocaleString()}-point loaded sample ` +
+        `(uniform-stride assumption). The loaded sample is what the viewer holds, ` +
+        `which may itself be a subset of the file.`,
     );
   }
 
@@ -570,7 +612,7 @@ export function spaceMetrics(
       ceilingAreaM2: ceilingPresent ? ceilCells * cellArea : null,
       wallCoveragePct, dominantWallDirections,
     },
-    storyCount, quality, reasons,
+    storyCount, quality, linearUnit, reasons,
   };
 }
 

--- a/tests/spaceMetrics.test.ts
+++ b/tests/spaceMetrics.test.ts
@@ -429,3 +429,66 @@ describe('spaceMetrics — reported dimensions', () => {
     expect(m.dims.lengthM).toBeCloseTo(shape.extent[2] / shape.aspect, 6);
   });
 });
+
+// ── The resolved linear-unit scale rides ON the metrics ─────────────────────
+// A factor of exactly 1 cannot tell a DECLARED metre CRS from an unknown local
+// scan, so consumers that only saw the factor read a real EPSG:6339 tile as
+// unverified. The CRS authority already knows the difference (`unitKnown`,
+// taken from SpatialContext.linearUnitKnown), so the verdict is resolved once
+// here and carried on the result instead of being re-inferred downstream.
+describe('spaceMetrics — the authoritative linear-unit scale', () => {
+  it('a DECLARED metre CRS (factor 1, unitKnown true) is KNOWN', () => {
+    const m = spaceMetrics(room(), {
+      upAxis: 'z', spaceKind: 'interior', unitToMetres: 1, unitKnown: true,
+    });
+    expect(m.linearUnit).toEqual({ known: true, metresPerUnit: 1 });
+  });
+
+  it('an explicitly unresolved unit stays UNKNOWN (fail closed)', () => {
+    const m = spaceMetrics(room(), {
+      upAxis: 'z', spaceKind: 'interior', unitToMetres: 1, unitKnown: false,
+    });
+    expect(m.linearUnit.known).toBe(false);
+  });
+
+  it('a legacy caller with no flag still fails closed at factor 1', () => {
+    expect(spaceMetrics(room(), { upAxis: 'z', spaceKind: 'interior' }).linearUnit.known)
+      .toBe(false);
+  });
+
+  it('a legacy caller with a foot factor stays KNOWN', () => {
+    const m = spaceMetrics(room(), {
+      upAxis: 'z', spaceKind: 'interior', unitToMetres: 0.3048,
+    });
+    expect(m.linearUnit).toEqual({ known: true, metresPerUnit: 0.3048 });
+  });
+
+  it('the too-few-points blank result carries the same verdict', () => {
+    const m = spaceMetrics(new Float32Array([0, 0, 0]), {
+      upAxis: 'z', spaceKind: 'interior', unitToMetres: 1, unitKnown: true,
+    });
+    expect(m.linearUnit).toEqual({ known: true, metresPerUnit: 1 });
+  });
+});
+
+// ── The stride caveat named the LOADED sample "the full scan" ───────────────
+describe('spaceMetrics — the stride caveat names the loaded sample', () => {
+  const m = spaceMetrics(room(), {
+    upAxis: 'z', spaceKind: 'interior', sourcePointCount: 1_888_921,
+  });
+  const caveat = m.reasons.find((r) => /scaled from a/.test(r))!;
+
+  it('calls the larger population the loaded sample, not the full scan', () => {
+    expect(caveat).toBeDefined();
+    expect(caveat).toContain('loaded sample');
+    expect(caveat).not.toMatch(/full [\d,]+-point scan/);
+  });
+
+  it('names the measured subset for what it is', () => {
+    expect(caveat).toContain('measured subset');
+  });
+
+  it('says the loaded sample may itself be a subset of the file', () => {
+    expect(caveat).toMatch(/subset of the file/);
+  });
+});

--- a/tests/spaceReportLayout.test.ts
+++ b/tests/spaceReportLayout.test.ts
@@ -47,7 +47,13 @@ const allText = (c: ReturnType<typeof buildSpaceReportContent>): string =>
 describe('buildSpaceReportContent — interior', () => {
   const pos = room();
   const shape = classifyScanShape(pos);
-  const space = spaceMetrics(pos, { upAxis: shape.up, spaceKind: 'interior', hasRgb: true });
+  // A DECLARED metre CRS (`unitKnown: true`), so the m + ft rows below are
+  // asserted against a scan whose scale the CRS authority actually resolved.
+  // Without the flag the scale is unverified and the rows print source units.
+  const space = spaceMetrics(pos, {
+    upAxis: shape.up, spaceKind: 'interior', hasRgb: true,
+    unitToMetres: 1, unitKnown: true,
+  });
   const content = buildSpaceReportContent({
     space,
     name: 'House 360',
@@ -86,7 +92,9 @@ describe('buildSpaceReportContent — interior', () => {
 
 describe('buildSpaceReportContent — object', () => {
   const pos = cubeShell();
-  const space = spaceMetrics(pos, { upAxis: 'z', spaceKind: 'object', hasRgb: true });
+  const space = spaceMetrics(pos, {
+    upAxis: 'z', spaceKind: 'object', hasRgb: true, unitToMetres: 1, unitKnown: true,
+  });
   const content = buildSpaceReportContent({
     space,
     object: objectMetrics(pos),
@@ -187,5 +195,151 @@ describe('buildSpaceReportContent — graceful (ceiling)', () => {
     expect(ceilingRow).toBeDefined();
     // null metric renders as an em-dash, never a fabricated zero.
     if (space.ceilingHeightM == null) expect(ceilingRow!.value).toBe('—');
+  });
+});
+
+// ── Unit suffixes must follow the SCALE, not the row ────────────────────────
+// Field defect: a real EPSG:6339 export printed "1270.87 x 977.35 x 268.22 m
+// (4169.5 x 3206.5 x 880.0 ft)" on the same page as
+// "Units  source units (scale unverified ...)". Every length / area / volume
+// row stamped m + ft with no reference to the scale at all, so an unverified
+// unit was published as metres AND converted to feet on top of it.
+const rowValues = (c: ReturnType<typeof buildSpaceReportContent>): string[] =>
+  c.sections.flatMap((s) => s.rows.map((r) => r.value));
+
+/** Any physical-unit suffix a scale-unverified report must never print. */
+const UNIT_CLAIM = /\b(m|ft|cm)\b|m²|m³|ft²|ft³/;
+
+describe('buildSpaceReportContent — unit suffixes follow the scale', () => {
+  const pos = room();
+  const shape = classifyScanShape(pos);
+  const obj = cubeShell();
+
+  const unknownInterior = buildSpaceReportContent({
+    space: spaceMetrics(pos, {
+      upAxis: shape.up, spaceKind: 'interior', hasRgb: true, unitKnown: false,
+    }),
+    name: 'Unverified scan',
+  });
+  const unknownObject = buildSpaceReportContent({
+    space: spaceMetrics(obj, { upAxis: 'z', spaceKind: 'object', hasRgb: true, unitKnown: false }),
+    object: objectMetrics(obj),
+    name: 'Unverified object',
+  });
+
+  it('an UNKNOWN scale prints no metre, foot or centimetre suffix anywhere', () => {
+    for (const content of [unknownInterior, unknownObject]) {
+      for (const value of rowValues(content)) {
+        expect(value, `unit claim in "${value}"`).not.toMatch(UNIT_CLAIM);
+      }
+    }
+  });
+
+  it('an UNKNOWN scale states the numbers are in source units', () => {
+    for (const content of [unknownInterior, unknownObject]) {
+      expect(rowValues(content).join(' | ')).toContain('source unit');
+      expect(content.provenance.units).toContain('source units');
+    }
+  });
+
+  it('an UNKNOWN scale never converts to feet', () => {
+    for (const content of [unknownInterior, unknownObject]) {
+      expect(rowValues(content).join(' | ')).not.toContain('ft');
+    }
+  });
+
+  it('a KNOWN metre CRS prints metres and does NOT disclaim the scale', () => {
+    const content = buildSpaceReportContent({
+      space: spaceMetrics(pos, {
+        upAxis: shape.up, spaceKind: 'interior', hasRgb: true,
+        unitToMetres: 1, unitKnown: true,
+      }),
+      name: 'NAD83(2011) / UTM 10N',
+    });
+    expect(content.provenance.units).toBe('metres');
+    expect(content.provenance.units).not.toContain('scale unverified');
+    const values = rowValues(content).join(' | ');
+    expect(values).toMatch(/\bm\b/);
+    expect(values).toMatch(/ft\)/);
+  });
+
+  it('a KNOWN foot CRS keeps the existing metre + foot conversion', () => {
+    const content = buildSpaceReportContent({
+      space: spaceMetrics(obj, {
+        upAxis: 'z', spaceKind: 'object', hasRgb: true,
+        unitToMetres: 0.3048, unitKnown: true,
+      }),
+      object: objectMetrics(obj),
+      name: 'Foot CRS',
+    });
+    expect(content.provenance.units).toBe('feet (source) → metres');
+    const values = rowValues(content).join(' | ');
+    expect(values).toMatch(/\bm\b/);
+    expect(values).toMatch(/ft³/);
+    expect(values).toMatch(/ft²/);
+  });
+
+  // The invariant that failed in the field, asserted directly.
+  it('never disclaims the scale and stamps a unit suffix on the same report', () => {
+    const cases = [
+      { unitKnown: false, unitToMetres: 1 },
+      { unitKnown: true, unitToMetres: 1 },
+      { unitKnown: true, unitToMetres: 0.3048 },
+      { unitKnown: undefined, unitToMetres: undefined },
+    ] as const;
+    for (const c of cases) {
+      const content = buildSpaceReportContent({
+        space: spaceMetrics(pos, {
+          upAxis: shape.up, spaceKind: 'interior', hasRgb: true,
+          unitToMetres: c.unitToMetres, unitKnown: c.unitKnown,
+        }),
+        name: 'Invariant',
+      });
+      const disclaims = content.provenance.units.includes('scale unverified');
+      const claims = rowValues(content).some((v) => UNIT_CLAIM.test(v));
+      expect(
+        disclaims && claims,
+        `units="${content.provenance.units}" but a row still stamps a unit`,
+      ).toBe(false);
+    }
+  });
+});
+
+// ── The "source" population was the LOADED display sample, not the file ─────
+// The field export read "59,029 / 1,888,921" while the file held 37,333,283
+// points, so "source" named the resident display sample and the notes called
+// it "the full scan".
+describe('buildSpaceReportContent — point populations are named honestly', () => {
+  const pos = room();
+  const shape = classifyScanShape(pos);
+  const content = buildSpaceReportContent({
+    space: spaceMetrics(pos, {
+      upAxis: shape.up, spaceKind: 'interior', hasRgb: true,
+      unitToMetres: 1, unitKnown: true, sourcePointCount: 1_888_921,
+    }),
+    name: 'Populations',
+  });
+  const pointsRow = content.sections
+    .flatMap((s) => s.rows)
+    .find((r) => r.label.startsWith('Points'))!;
+
+  it('names the measured subset and the loaded sample distinctly', () => {
+    expect(pointsRow).toBeDefined();
+    expect(`${pointsRow.label} ${pointsRow.value}`).toMatch(/measured/i);
+    expect(`${pointsRow.label} ${pointsRow.value}`).toMatch(/loaded/i);
+  });
+
+  it('never calls the loaded sample "source"', () => {
+    expect(`${pointsRow.label} ${pointsRow.value}`).not.toMatch(/source/i);
+    const pointsLine = content.provenanceLines.find((l) => l.startsWith('Points'))!;
+    expect(pointsLine).toBeDefined();
+    expect(pointsLine).not.toMatch(/source/i);
+    expect(pointsLine).toMatch(/loaded/i);
+  });
+
+  it('never calls the loaded sample "the full scan"', () => {
+    const notes = content.caveats.join(' | ');
+    expect(notes).not.toContain('full 1,888,921-point scan');
+    expect(notes).not.toMatch(/full [\d,]+-point scan/);
   });
 });


### PR DESCRIPTION
The space report disclaimed its own scale and stamped units on every figure anyway. A USGS tile in EPSG:6339, a metre CRS, printed `1270.87 x 977.35 x 268.22 m (4169.5 x 3206.5 x 880.0 ft)` above the line `Units: source units (scale unverified, not asserted as metres)`.

Two causes. Every dimension row appended metres and a foot conversion with no check of the scale, and `scaleFromFactor` read a metres-per-unit factor of exactly 1 as unknown, so a declared metre CRS disclaimed itself. The authoritative flag already reached `spaceMetrics` from the CRS context and stopped one layer short of the report.

Suffixes now come from one format record chosen by the resolved scale. The points row reads `measured / loaded` instead of calling the loaded sample the source.
