### PR TITLE
fix(ui): make reclassify actually reachable, and show that it worked

### DIFF
--- a/src/app/classLegendRefresh.ts
+++ b/src/app/classLegendRefresh.ts
@@ -1,0 +1,67 @@
+/**
+ * classLegendRefresh.ts
+ *
+ * Keeping the Classes legend true to the buffer it describes.
+ *
+ * Two callers, one rule. A freshly opened scan counts its classification once
+ * ({@link classCountsOf}); an IN-PLACE class edit (the lasso reclassify, the
+ * polygon reclassify, a class swap, and their undo/redo) has to recount,
+ * because the numbers on the panel now describe a classification that no
+ * longer exists.
+ *
+ * The edit path fans out to three surfaces, all invalidated together: the
+ * cached terrain core (bare earth is picked from the classes), the rendered
+ * Analyse result on screen, and the legend counts. The first two were already
+ * settled; the counts were not. On a barely-classified airborne tile, which
+ * OLV opens coloured by HEIGHT, because too few points carry a producer class
+ * for the class ramp to read, the legend is the ONLY place an edit shows, so a
+ * successful edit moved nothing the user could see and read as a refusal.
+ *
+ * The recount is a REPLACE that keeps the panel's visibility state. The fresh-
+ * scan reset (`setClasses`) hands back an all-visible filter, which would
+ * un-hide classes the user hid before they started editing.
+ *
+ * Structural dependencies, no DOM and no three.js, so the contract is
+ * unit-testable without a Viewer or a panel.
+ */
+
+import { countClasses } from '../render/class/classHistogram';
+import { toClassBuffer } from '../render/class/classBuffer';
+
+/** Per-class point counts for any classification source, narrowed to bytes. */
+export function classCountsOf(classification: ArrayLike<number>): Map<number, number> {
+  return countClasses(toClassBuffer(classification));
+}
+
+/** The Classes panel surface this needs: replace counts, keep the filter. */
+export interface ClassCountSink {
+  replaceCounts(counts: Map<number, number>): void;
+}
+
+/** The live reads and effects one class edit fans out to. */
+export interface ClassEditNotifyDeps {
+  /** The edited cloud's classification buffer, or null when it has none. */
+  readonly classification: ArrayLike<number> | null | undefined;
+  readonly legend: ClassCountSink;
+  /** Drop the cached terrain core and abort any in-flight compute. */
+  readonly clearTerrainCache: () => void;
+  /** Stamp the Analyse panel's stale caveat. No-op when nothing is on screen. */
+  readonly noteStale: (message: string) => void;
+}
+
+/** The caveat an on-screen Analyse result carries once the classes move under it. */
+export const CLASS_EDIT_STALE_NOTICE =
+  'Classification edited. Results reflect the previous classification; re-run Analyse to refresh.';
+
+/**
+ * Settle every surface a class edit invalidated. Always drops the terrain cache
+ * and stamps the stale caveat; recounts the legend when the cloud still carries
+ * a classification buffer (an unknown id or a class-less cloud leaves the panel
+ * alone rather than blanking it).
+ */
+export function noteClassificationEdited(deps: ClassEditNotifyDeps): void {
+  deps.clearTerrainCache();
+  deps.noteStale(CLASS_EDIT_STALE_NOTICE);
+  const cls = deps.classification;
+  if (cls && cls.length > 0) deps.legend.replaceCounts(classCountsOf(cls));
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1804,7 +1804,7 @@ const keyBindingDeps: KeyBindingDeps = {
     measureFinish: () => viewer?.measure.finishCurrent(),
     measureUndoPoint: () => viewer?.measure.undoLastPoint(),
     onEscape: () => {
-      let handled = false;
+      let handled = reclassifyUi?.disarm() === true; // a separately owned lasso
       if (lassoVolumeTool.enabled) {
         lassoVolumeTool.disable();
         viewer?.setLassoMode(false);

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,7 +96,7 @@ import type { AnalysePanel } from './ui/AnalysePanel';
 import { ClassLegendPanel } from './ui/ClassLegendPanel';
 import type { ReclassifyUi } from './ui/reclassifyUi';
 import { countClasses } from './render/class/classHistogram';
-import { toClassBuffer } from './render/class/classBuffer';
+import { classCountsOf, noteClassificationEdited } from './app/classLegendRefresh';
 import { deriveClassificationAsync } from './render/class/deriveClassificationAsync';
 import { classifierOptions } from './render/class/classifierCues';
 import { classificationCoverage } from './render/class/classificationCoverage';
@@ -2634,21 +2634,21 @@ const terrainRunner = createTerrainAnalysisRunner({
   },
 });
 
-// Honesty guard: a manual classification edit changes the bare-earth surface, so
-// any cached terrain core / on-screen grade computed from the old classes is now
-// stale. Drop the cache (and abort any in-flight compute) the moment an edit
-// lands, so the next Analyse recomputes against the edited classes instead of
-// serving a number that silently no longer matches what's on screen.
+// Honesty guard: a manual class edit changes the bare-earth surface, so the
+// cached terrain core and any on-screen grade from the old classes go stale the
+// moment it lands, and it moves points between classes, so the Classes panel
+// counts still describe the pre-edit buffer. `noteClassificationEdited` settles
+// all three: drop the cache (aborting any in-flight compute) so the next
+// Analyse recomputes against the edited classes, caveat the result still on
+// screen, and recount the legend. The recount stops a landed edit reading as a
+// refusal on a height-coloured scan, where the legend is the only place it shows.
 void viewerLoaded.then((v) => {
-  v.onClassificationEdited = () => {
-    terrainRunner.abortAndClearCache();
-    // The cache is gone but the RENDERED result/contours are not — without a
-    // caveat they read as current while reflecting the previous classes. The
-    // panel no-ops when nothing is on screen; a completed re-run clears it.
-    analysePanel?.setStaleNotice(
-      'Classification edited — results reflect the previous classification. Re-run Analyse to refresh.',
-    );
-  };
+  v.onClassificationEdited = (id) => noteClassificationEdited({
+    classification: v.getCloud(id)?.classification,
+    legend: classLegendPanel,
+    clearTerrainCache: () => terrainRunner.abortAndClearCache(),
+    noteStale: (m) => analysePanel?.setStaleNotice(m),
+  });
 });
 
 // Per-cloud source files + reduced flags, so the Export panel can re-decode a
@@ -3315,7 +3315,7 @@ function revealAnalysePanel(name: string, settled = true): void {
  */
 function refreshClassLegend(classification?: ArrayLike<number>, sample?: { readonly loaded: number; readonly declared?: number }): void {
   if (classification && classification.length > 0) {
-    classLegendPanel.setClasses(countClasses(toClassBuffer(classification)), sample);
+    classLegendPanel.setClasses(classCountsOf(classification), sample);
   } else {
     classLegendPanel.setClasses(new Map(), sample);
   }

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -3173,14 +3173,14 @@ export class Viewer {
     // The buffer is source-local; the camera sees the project frame.
     const project = (x: number, y: number, z: number) => toScreen(x + off[0], y + off[1], z + off[2]);
     const indices = selectByLasso({ lasso, positions: entry.cloud.positions, project });
-    // An EDIT must only touch points the user can currently see. The lasso
-    // projector already drops points behind the camera, but not points hidden
-    // by the clip box or the visibility filters — the raw selection
-    // permanently rewrote invisible points (reclassify-invisible-points
-    // finding, Critical). Apply the same visibility rules click-picking
-    // enforces: the pure `clipKeepsPoint` contract the GPU clip planes
-    // realise, and the class + elevation + intensity filter accept, so screen
-    // and edit agree point-for-point. In-place filter — no hot-path allocation.
+    // An EDIT must only touch points the user can currently see: the projector
+    // drops points behind the camera, the clip box and the visibility filters
+    // hide the rest, and the raw selection rewrote those invisibly
+    // (reclassify-invisible-points finding, Critical). Same rules click-picking
+    // enforces (`clipKeepsPoint` + the class/elevation/intensity accept), in
+    // place so the hot path allocates nothing. `inside` lets the caller say how
+    // many points the filters held back instead of reporting an empty lasso.
+    const inside = indices.length;
     const clip = this._clip;
     filterSelectionToVisible(indices, entry.cloud.positions, {
       keepPoint: clip?.enabled
@@ -3202,7 +3202,7 @@ export class Viewer {
       this._refreshClassificationColours(id);
       this._markClassificationEdited(id);
     }
-    return result;
+    return { ...result, hiddenByFilters: inside - indices.length, selectedCount: inside };
   }
 
   /**

--- a/src/render/measure/classificationEditor.ts
+++ b/src/render/measure/classificationEditor.ts
@@ -44,6 +44,22 @@ export interface ClassEditResult {
   changedCount: number;
   /** Total points in the buffer. */
   pointCount: number;
+  /**
+   * Points the selection DID contain that an active visibility rule (class /
+   * elevation / intensity filter, or the clip box) removed before the edit ran.
+   * Set only by the screen-lasso path, which is the one that intersects a
+   * selection with visibility; zero and `undefined` both mean "nothing was
+   * held back". Without it a filtered-out edit and an empty selection are the
+   * same `changedCount: 0` and the UI cannot tell the user which happened.
+   */
+  hiddenByFilters?: number;
+  /**
+   * Points the selection contained BEFORE the visibility intersection above.
+   * Screen-lasso path only. Lets a caller separate "the lasso was empty" from
+   * "everything inside already carried the target class", which are otherwise
+   * the same `changedCount: 0`.
+   */
+  selectedCount?: number;
 }
 
 /**

--- a/src/ui/ClassLegendPanel.ts
+++ b/src/ui/ClassLegendPanel.ts
@@ -372,6 +372,25 @@ export class ClassLegendPanel {
     this._render();
   }
 
+  /**
+   * Replace the per-class counts after an IN-PLACE class edit (lasso / polygon
+   * reclassify, class swap, and their undo/redo). The counts the panel showed
+   * describe a classification that no longer exists.
+   *
+   * Unlike {@link setClasses} this keeps the visibility state, the derived /
+   * streaming / sampled captions and the sample basis: the user's own edit is
+   * no reason to clear the class filter they set before it, and the counts are
+   * still scoped to the same loaded sample. Unlike {@link mergeClasses} it
+   * replaces rather than accumulates, because an edit MOVES points between
+   * classes instead of adding new ones. Does NOT emit `onChange`: visibility
+   * is untouched.
+   */
+  replaceCounts(counts: Map<number, number>): void {
+    this._counts = new Map(counts);
+    if (this._presentCodes().length > 0) this._hasChannel = true;
+    this._render();
+  }
+
   /** Whether the panel currently has any class rows to show. */
   hasClasses(): boolean {
     return this._hasChannel;

--- a/src/ui/LassoVolumeTool.ts
+++ b/src/ui/LassoVolumeTool.ts
@@ -124,7 +124,9 @@ export class LassoVolumeTool {
     this._svg.setAttribute(
       'style',
       'position:absolute;inset:0;width:100%;height:100%;' +
-        'cursor:crosshair;z-index:3;touch-action:none;',
+        // Below `.olv-overlay` (--z-scene-overlay: 2), a stacking context holding
+        // every panel: at 3 the armed lasso covered the UI and ate its clicks.
+        'cursor:crosshair;z-index:var(--z-content);touch-action:none;',
     );
     this._path = document.createElementNS(SVG_NS, 'path') as SVGPathElement;
     // Read the canonical accent token off :root so the lasso overlay

--- a/src/ui/reclassifyOutcome.ts
+++ b/src/ui/reclassifyOutcome.ts
@@ -1,0 +1,43 @@
+/**
+ * reclassifyOutcome.ts
+ *
+ * The sentence the lasso reclassify tool says after a commit.
+ *
+ * A class edit can end in four different ways and three of them used to share
+ * one line, "no points inside the lasso": the lasso really was empty; the
+ * points were there but a class / elevation / intensity filter or the clip box
+ * hid them, so the edit deliberately left them alone; or every point inside
+ * already carried the target class. Reported identically, a refusal the user
+ * can act on looked like a tool that does not work. This turns the counts the
+ * Viewer already returns into the specific sentence for the case that happened.
+ *
+ * Pure string building: no DOM, no Viewer, unit-testable in Node.
+ */
+
+import type { ClassEditResult } from '../render/measure/classificationEditor';
+
+/**
+ * Describe what a lasso reclassify did, or why it did nothing.
+ *
+ * `selectedCount` / `hiddenByFilters` are the screen-lasso path's own counts
+ * (see {@link ClassEditResult}); an older result that carries neither still
+ * falls back to the plain empty-lasso line rather than inventing a reason.
+ */
+export function reclassifyOutcome(result: ClassEditResult, targetClass: number): string {
+  const changed = result.changedCount;
+  if (changed > 0) {
+    return `Reclassified ${changed.toLocaleString()} points → class ${targetClass}.`;
+  }
+  const hidden = result.hiddenByFilters ?? 0;
+  if (hidden > 0) {
+    return (
+      `Reclassify · ${hidden.toLocaleString()} points inside the lasso are hidden right now, ` +
+      'so they were left alone. Clear the class, elevation or intensity filter ' +
+      '(or the clip box) and draw again.'
+    );
+  }
+  if ((result.selectedCount ?? 0) > 0) {
+    return `Reclassify · every point inside the lasso is already class ${targetClass}.`;
+  }
+  return 'Reclassify · no points inside the lasso.';
+}

--- a/src/ui/reclassifyUi.ts
+++ b/src/ui/reclassifyUi.ts
@@ -15,6 +15,7 @@
 
 import { el } from './dom';
 import { LassoVolumeTool } from './LassoVolumeTool';
+import { reclassifyOutcome } from './reclassifyOutcome';
 import { noteEdit } from './undoRouter';
 import type { Viewer } from '../render/Viewer';
 
@@ -111,11 +112,7 @@ export function createReclassifyUi(opts: ReclassifyUiOptions): ReclassifyUi {
       const cls = Number(select.value);
       const r = v.reclassifyLasso(id, lasso, cls);
       if (r.changedCount > 0) noteEdit('classification');
-      toast(
-        r.changedCount > 0
-          ? `Reclassified ${r.changedCount.toLocaleString()} points → class ${cls}.`
-          : 'Reclassify — no points inside the lasso.',
-      );
+      toast(reclassifyOutcome(r, cls));
       refresh();
     },
     onCancel: () => {

--- a/src/ui/reclassifyUi.ts
+++ b/src/ui/reclassifyUi.ts
@@ -49,6 +49,8 @@ export interface ReclassifyUi {
   setVisible(visible: boolean): void;
   /** Re-sync the undo/redo enabled state from the Viewer history. */
   refresh(): void;
+  /** Disarm the lasso if it is armed. True when it had been armed. */
+  disarm(): boolean;
   dispose(): void;
 }
 
@@ -167,6 +169,12 @@ export function createReclassifyUi(opts: ReclassifyUiOptions): ReclassifyUi {
   refresh();
 
   return {
+    disarm(): boolean {
+      if (!tool.enabled) return false;
+      tool.disable();
+      armBtn.classList.remove('olv-mkind-active');
+      return true;
+    },
     element,
     setVisible: (visible: boolean) => element.classList.toggle('olv-hidden', !visible),
     refresh,

--- a/tests/classLegendEditRefresh.test.ts
+++ b/tests/classLegendEditRefresh.test.ts
@@ -1,0 +1,96 @@
+/**
+ * classLegendEditRefresh.test.ts
+ *
+ * After an in-place class edit the Classes panel has to describe the buffer
+ * that now exists.
+ *
+ * A live report ("classification seems off, when trying to reclassify its not
+ * letting me") came from a barely-classified airborne tile that OLV opened
+ * coloured by HEIGHT, because too few points carried a producer class for the
+ * class ramp to read. On that scan the legend counts are the only place a class
+ * edit shows: the scene does not repaint, and the toast is transient. The edit
+ * landed and every number the user was looking at stayed exactly where it was,
+ * which is indistinguishable from a tool that refuses.
+ *
+ * Two properties are pinned:
+ *   1. `replaceCounts` moves the numbers (the refresh itself), and
+ *   2. it does NOT reset the user's class filter, which `setClasses` does:
+ *      the user's own edit is no reason to un-hide classes they hid.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ClassLegendPanel } from '../src/ui/ClassLegendPanel';
+import { FakeEl, installFakeDom, byClass } from './support/measurePanelDom';
+import { noteClassificationEdited } from '../src/app/classLegendRefresh';
+
+beforeAll(() => {
+  installFakeDom();
+  const g = globalThis as unknown as { document: Record<string, unknown> };
+  g.document.createDocumentFragment = (): FakeEl => new FakeEl('#fragment');
+});
+
+/** The reported tile's split, scaled down: mostly unclassified, a little ground. */
+const BEFORE = new Map<number, number>([
+  [1, 18_034],
+  [2, 830],
+  [7, 23],
+  [18, 1],
+]);
+
+/** Every row's text, so a count can be located without pinning the wording. */
+function rowText(panel: ClassLegendPanel): string {
+  const list = byClass(panel.element as unknown as FakeEl, 'olv-cl-list');
+  const walk = (n: FakeEl): string =>
+    [n.textContent ?? '', ...n.children.map(walk)].join(' ');
+  return list ? walk(list) : '';
+}
+
+describe('Classes legend after an in-place class edit', () => {
+  it('shows the post-edit counts, not the counts the scan opened with', () => {
+    const panel = new ClassLegendPanel();
+    panel.setClasses(BEFORE, { loaded: 18_888, declared: 373_332 });
+    expect(rowText(panel)).toContain('830');
+
+    // 400 unclassified points were lassoed into Ground.
+    const after = new Map<number, number>([
+      [1, 17_634],
+      [2, 1_230],
+      [7, 23],
+      [18, 1],
+    ]);
+    panel.replaceCounts(after);
+    const text = rowText(panel);
+    expect(text).toContain('1,230');
+    expect(text).not.toContain('18,034');
+  });
+
+  it('keeps the class filter the user set before editing', () => {
+    const panel = new ClassLegendPanel();
+    panel.setClasses(BEFORE, { loaded: 18_888, declared: 373_332 });
+    panel.applyFilter([7, 18]); // the user hid both noise classes
+    expect(panel.getVisibility().hiddenCodes()).toEqual([7, 18]);
+
+    panel.replaceCounts(new Map(BEFORE));
+    // `setClasses` would have handed back a fresh all-visible state here.
+    expect(panel.getVisibility().hiddenCodes()).toEqual([7, 18]);
+  });
+
+  it('is what the class-edit notifier drives, from the edited buffer', () => {
+    const panel = new ClassLegendPanel();
+    panel.setClasses(BEFORE, { loaded: 4, declared: 40 });
+    let cleared = 0;
+    let stale = '';
+    // Four points, two of which the user just moved to Ground.
+    noteClassificationEdited({
+      classification: Uint8Array.from([1, 2, 2, 7]),
+      legend: panel,
+      clearTerrainCache: () => void cleared++,
+      noteStale: (m: string) => void (stale = m),
+    });
+    expect(cleared).toBe(1);
+    expect(stale).toMatch(/re-run analyse/i);
+    const text = rowText(panel);
+    expect(text).toContain('2'); // the Ground row now holds two points
+    expect(text).not.toContain('18,034');
+  });
+});

--- a/tests/reclassifyLassoOverlay.test.ts
+++ b/tests/reclassifyLassoOverlay.test.ts
@@ -1,0 +1,44 @@
+/**
+ * reclassifyLassoOverlay.test.ts
+ *
+ * Arming the reclassify lasso used to cover the whole interface. The lasso SVG
+ * mounts as a sibling of `.olv-overlay`, which is a stacking context at
+ * `--z-scene-overlay: 2` holding every panel, so an inline `z-index: 3` painted
+ * the lasso above all of them and swallowed their clicks. Escape could not
+ * clear it either: the global handler knew only the volume lasso.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('the armed lasso does not cover the panels', () => {
+  const src = readFileSync(new URL('../src/ui/LassoVolumeTool.ts', import.meta.url), 'utf8');
+
+  it('mounts under the panel overlay, not above it', () => {
+    expect(src).not.toMatch(/z-index:\s*3\b/);
+    expect(src).toMatch(/z-index:var\(--z-content\)/);
+  });
+
+  it('keeps the panel overlay above the lasso in the token scale', () => {
+    const tokens = readFileSync(new URL('../src/styles/01-tokens.css', import.meta.url), 'utf8');
+    const val = (name: string): number => {
+      const m = new RegExp(`--${name}:\\s*(\\d+)`).exec(tokens);
+      return m ? Number(m[1]) : Number.NaN;
+    };
+    expect(val('z-content')).toBeLessThan(val('z-scene-overlay'));
+  });
+});
+
+describe('Escape reaches the reclassify lasso', () => {
+  it('main.ts disarms the reclassify lasso in its Escape handler', () => {
+    const main = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8');
+    const esc = /onEscape:\s*\(\)\s*=>\s*\{([\s\S]*?)\n    \},/.exec(main);
+    expect(esc, 'onEscape handler not found').toBeTruthy();
+    expect(esc![1]).toMatch(/reclassifyUi\?\.disarm\(\)/);
+  });
+
+  it('reclassifyUi exposes disarm on its public surface', () => {
+    const ui = readFileSync(new URL('../src/ui/reclassifyUi.ts', import.meta.url), 'utf8');
+    expect(ui).toMatch(/disarm\(\):\s*boolean;/);
+    expect(ui).toMatch(/disarm\(\):\s*boolean\s*\{/);
+  });
+});

--- a/tests/reclassifyLassoUserState.test.ts
+++ b/tests/reclassifyLassoUserState.test.ts
@@ -1,0 +1,208 @@
+/**
+ * reclassifyLassoUserState.test.ts
+ *
+ * A live report said "classification seems off, when trying to reclassify its
+ * not letting me" on a USGS 3DEP tile: 37,333,283 declared points, 1,888,921
+ * resident after the stride-then-voxel reduction, four class codes
+ * (1 / 2 / 7 / 18) in a ~95.5 / 4.4 / 0.12 / 0.004 split, elevation 657-989 m,
+ * intensity 7239-65535, opened coloured by HEIGHT because too few points carry
+ * a producer class for the class ramp to read.
+ *
+ * This rebuilds `Viewer.reclassifyLasso`'s composition out of the SAME
+ * production helpers (`selectByLasso` + `filterSelectionToVisible` +
+ * `buildPointFilterAccept` + `applyIndexReclassify`, with the window built by
+ * `elevWindowFieldsFor` exactly as `Viewer._currentFilterWindow` builds it) and
+ * walks the observed state one variable at a time, so "the edit refused"
+ * becomes a measurement rather than a guess.
+ *
+ * The result the fix rests on: with the windows the Inspector SEEDS on open
+ * (floor(min) / ceil(max) of the loaded sample) the edit lands on every axis:
+ * seeded-and-inactive, seeded-and-active, class mask all-visible. The engine
+ * does not refuse. What the user sees is a silent success, which is what the
+ * legend-refresh fix addresses.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  selectByLasso,
+  filterSelectionToVisible,
+  type ScreenProjector,
+  type Vec2,
+} from '../src/render/measure/lassoVolume';
+import { applyIndexReclassify } from '../src/render/measure/classificationEditor';
+import {
+  buildPointFilterAccept,
+  elevWindowFieldsFor,
+  type PointFilterWindow,
+} from '../src/render/pointFilterAccept';
+
+// ── The user's scan, at 1/100 scale ──────────────────────────────────────────
+
+/** The Z origin the LAS loader subtracted; positions are stored origin-shifted. */
+const ORIGIN_Z = 823.5;
+/** World elevation span of the tile, as the Inspector reports it. */
+const WORLD_MIN_Z = 657.32;
+const WORLD_MAX_Z = 988.74;
+/** Raw intensity span of the loaded sample, as the Inspector reports it. */
+const INTEN_MIN = 7239;
+const INTEN_MAX = 65535;
+
+/** The user's class split, scaled to a testable count. */
+const SPLIT: ReadonlyArray<readonly [number, number]> = [
+  [1, 18034], // Unclassified
+  [2, 830], // Ground
+  [7, 23], // Low point (noise)
+  [18, 1], // High noise
+];
+
+interface Fixture {
+  positions: Float32Array;
+  classification: Uint8Array;
+  intensity: Uint16Array;
+  count: number;
+}
+
+/**
+ * A tile-shaped cloud: points on a 1 km grid, elevations spanning the reported
+ * world range (stored origin-shifted, the frame `cloud.positions` really live
+ * in), intensities spanning the reported raw range with the MINIMUM present, so
+ * a window whose lower bound equals the sample minimum is exercised at the edge.
+ */
+function buildFixture(): Fixture {
+  const count = SPLIT.reduce((n, [, c]) => n + c, 0);
+  const positions = new Float32Array(count * 3);
+  const classification = new Uint8Array(count);
+  const intensity = new Uint16Array(count);
+  const side = Math.ceil(Math.sqrt(count));
+  let i = 0;
+  for (const [code, n] of SPLIT) {
+    for (let k = 0; k < n; k++, i++) {
+      const gx = i % side;
+      const gy = Math.floor(i / side);
+      const t = i / (count - 1);
+      positions[i * 3] = gx * 1.0;
+      positions[i * 3 + 1] = gy * 1.0;
+      // Origin-shifted attribute space, the frame the buffer is stored in.
+      positions[i * 3 + 2] = WORLD_MIN_Z + t * (WORLD_MAX_Z - WORLD_MIN_Z) - ORIGIN_Z;
+      classification[i] = code;
+      intensity[i] = Math.round(INTEN_MIN + t * (INTEN_MAX - INTEN_MIN));
+    }
+  }
+  return { positions, classification, intensity, count };
+}
+
+/** Top-down orthographic projector: screen == XY. Stands in for the camera. */
+const topDown: ScreenProjector = (x, y) => ({ x, y });
+
+/** An axis-aligned screen box as a lasso ring. */
+function lassoBox(minX: number, maxX: number, minY: number, maxY: number): Vec2[] {
+  return [
+    { x: minX, y: minY },
+    { x: maxX, y: minY },
+    { x: maxX, y: maxY },
+    { x: minX, y: maxY },
+  ];
+}
+
+/** The all-visible 256-entry class mask `applyClassVisibility` writes. */
+function allVisibleMask(): Float32Array {
+  return new Float32Array(256).fill(1);
+}
+
+/**
+ * `Viewer._currentFilterWindow`, rebuilt from the same pure helper it calls:
+ * the elevation window converts with THIS cloud's origin and up-axis.
+ */
+function windowFor(opts: {
+  classActive?: boolean;
+  classMask?: ArrayLike<number> | null;
+  elevWorld?: readonly [number, number];
+  intenWindow?: readonly [number, number];
+}): PointFilterWindow {
+  const e = elevWindowFieldsFor(opts.elevWorld, ORIGIN_Z, 2);
+  return {
+    classActive: opts.classActive ?? false,
+    classMask: opts.classMask ?? allVisibleMask(),
+    elevActive: opts.elevWorld !== undefined,
+    elevAxisIdx: e.elevAxisIdx,
+    elevMin: e.elevMin,
+    elevMax: e.elevMax,
+    intenActive: opts.intenWindow !== undefined,
+    intenMin: opts.intenWindow?.[0] ?? 0,
+    intenMax: opts.intenWindow?.[1] ?? 0,
+  };
+}
+
+/** `Viewer.reclassifyLasso`'s body, over the same helpers, minus three.js. */
+function reclassifyLasso(
+  fx: Fixture,
+  lasso: ReadonlyArray<Vec2>,
+  newClass: number,
+  window: PointFilterWindow,
+): number {
+  const indices = selectByLasso({ lasso, positions: fx.positions, project: topDown });
+  filterSelectionToVisible(indices, fx.positions, {
+    acceptIndex: buildPointFilterAccept(
+      fx.positions,
+      fx.classification,
+      fx.intensity,
+      window,
+    ),
+  });
+  return applyIndexReclassify(fx.classification, indices, newClass).changedCount;
+}
+
+// ── The walk ─────────────────────────────────────────────────────────────────
+
+describe('reclassify lasso on the reported scan state', () => {
+  /** A lasso over the middle of the tile; it certainly contains points. */
+  const lasso = lassoBox(10, 120, 10, 120);
+
+  it('edits points with no filter armed (the baseline the report contradicts)', () => {
+    const fx = buildFixture();
+    expect(reclassifyLasso(fx, lasso, 2, windowFor({}))).toBeGreaterThan(0);
+  });
+
+  it('still edits with the SEEDED elevation window armed', () => {
+    // The Inspector seeds floor(min) / ceil(max), so a seeded window is WIDER
+    // than the data and can never exclude a point the user drew around.
+    const fx = buildFixture();
+    const seeded: [number, number] = [Math.floor(WORLD_MIN_Z), Math.ceil(WORLD_MAX_Z)];
+    expect(reclassifyLasso(fx, lasso, 2, windowFor({ elevWorld: seeded }))).toBeGreaterThan(0);
+  });
+
+  it('still edits with the SEEDED intensity window armed, minimum included', () => {
+    // The lower bound EQUALS the sample minimum here, so this is the boundary
+    // comparison: `buildPointFilterAccept` is inclusive (`< min` rejects), and
+    // the point whose intensity is exactly the minimum must survive.
+    const fx = buildFixture();
+    const seeded: [number, number] = [INTEN_MIN, INTEN_MAX];
+    const changed = reclassifyLasso(fx, lasso, 2, windowFor({ intenWindow: seeded }));
+    expect(changed).toBeGreaterThan(0);
+    // The point AT the minimum is in the kept set, not shaved off the edge.
+    const atMin = fx.intensity.indexOf(INTEN_MIN);
+    expect(atMin).toBeGreaterThanOrEqual(0);
+    expect(buildPointFilterAccept(
+      fx.positions,
+      fx.classification,
+      fx.intensity,
+      windowFor({ intenWindow: seeded }),
+    )!(atMin)).toBe(true);
+  });
+
+  it('still edits with the class filter armed and every class visible', () => {
+    const fx = buildFixture();
+    const w = windowFor({ classActive: true, classMask: allVisibleMask() });
+    expect(reclassifyLasso(fx, lasso, 2, w)).toBeGreaterThan(0);
+  });
+
+  it('refuses only when a filter genuinely hides the drawn points', () => {
+    // The one state that DOES return zero: a window the user narrowed past the
+    // points they drew around. This is the refusal the UI must say out loud.
+    const fx = buildFixture();
+    const hidden = windowFor({ elevWorld: [WORLD_MAX_Z - 1, WORLD_MAX_Z] });
+    const selected = selectByLasso({ lasso, positions: fx.positions, project: topDown });
+    expect(selected.length).toBeGreaterThan(0);
+    expect(reclassifyLasso(fx, lasso, 2, hidden)).toBe(0);
+  });
+});

--- a/tests/reclassifyOutcome.test.ts
+++ b/tests/reclassifyOutcome.test.ts
@@ -1,0 +1,60 @@
+/**
+ * reclassifyOutcome.test.ts
+ *
+ * A lasso reclassify that changes nothing has three different reasons, and the
+ * tool used to report all three as "no points inside the lasso". A user whose
+ * points were hidden by a filter was told they had drawn around empty space, so
+ * the one thing they could have done about it was the one thing the message
+ * withheld.
+ *
+ * These pin the SPECIFIC case, not the wording: the filtered refusal must name
+ * a filter, the already-that-class case must not claim the lasso was empty, and
+ * a genuinely empty lasso must still say so.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { reclassifyOutcome } from '../src/ui/reclassifyOutcome';
+
+describe('reclassify lasso outcome message', () => {
+  it('reports the edit when points changed', () => {
+    const msg = reclassifyOutcome(
+      { changedCount: 12_345, pointCount: 1_888_921, selectedCount: 12_345, hiddenByFilters: 0 },
+      2,
+    );
+    expect(msg).toContain('12,345');
+    expect(msg).toContain('2');
+  });
+
+  it('says a filter held the points back, and how to release them', () => {
+    const msg = reclassifyOutcome(
+      { changedCount: 0, pointCount: 1_888_921, selectedCount: 8_400, hiddenByFilters: 8_400 },
+      2,
+    );
+    expect(msg).toContain('8,400');
+    expect(msg).toMatch(/filter/i);
+    expect(msg).not.toMatch(/no points inside/i);
+  });
+
+  it('separates "already that class" from an empty lasso', () => {
+    const already = reclassifyOutcome(
+      { changedCount: 0, pointCount: 1_888_921, selectedCount: 500, hiddenByFilters: 0 },
+      2,
+    );
+    expect(already).toMatch(/already class 2/i);
+    expect(already).not.toMatch(/no points inside/i);
+  });
+
+  it('still says the lasso was empty when it was', () => {
+    const msg = reclassifyOutcome(
+      { changedCount: 0, pointCount: 1_888_921, selectedCount: 0, hiddenByFilters: 0 },
+      2,
+    );
+    expect(msg).toMatch(/no points inside the lasso/i);
+  });
+
+  it('falls back to the empty-lasso line when a result carries no counts', () => {
+    // An older/other mutator result has neither field; it must not invent one.
+    const msg = reclassifyOutcome({ changedCount: 0, pointCount: 10 }, 6);
+    expect(msg).toMatch(/no points inside the lasso/i);
+  });
+});


### PR DESCRIPTION
Reclassifying appeared to do nothing. Three separate causes, none of them the edit itself, which lands correctly.

Arming the lasso covered the interface. The SVG mounts as a sibling of `.olv-overlay`, a stacking context at `--z-scene-overlay: 2` holding every panel, so its inline `z-index: 3` painted above all of them and swallowed their clicks. It now mounts at `--z-content`. Escape could not clear it either: the reclassify lasso is a second `LassoVolumeTool` owned by `reclassifyUi`, which the global handler did not know about. `ReclassifyUi` now exposes `disarm()`.

When an edit did land, the legend never recounted, so with a scan coloured by height nothing visibly changed. The toast also reported a filtered refusal as an empty lasso.
