### PR TITLE
fix(report): claim only what the space report measures

### DIFF
--- a/src/render/measure/spaceReportPdf.ts
+++ b/src/render/measure/spaceReportPdf.ts
@@ -111,6 +111,13 @@ export async function buildSpaceReportPdf(input: SpaceReportPdfInput): Promise<U
       text(row.label, labelX, y, 9.5, bold, DIM);
       text(row.value, valueX, y, 9.5, font, INK);
       y -= 14;
+      // The per-row qualifier the panel shows as a tooltip. Without it the
+      // sheet printed a bare envelope volume and a bare bounding surface area,
+      // so a reader had no way to tell either one from a solid measurement.
+      if (row.hint) {
+        y = drawWrapped(page, font, row.hint, valueX, y, PW - M - valueX, 7, DIM);
+        y -= 1;
+      }
     }
     y -= 8;
   }

--- a/src/terrain/objectMetrics.ts
+++ b/src/terrain/objectMetrics.ts
@@ -10,9 +10,12 @@
  *   - envelope volume (the OBB volume) — an honest bound, NOT a solid volume
  *     (a point cloud has no watertight interior; that needs a mesh);
  *   - median nearest-neighbour spacing — the scan's effective resolution;
- *   - angular completeness — the fraction of viewing directions around the
- *     object's centroid that actually have returns, i.e. how much of the
- *     surface was captured vs occluded / missed;
+ *   - angular coverage: the fraction of direction bins around the point set's
+ *     centroid that have returns. It describes the SHAPE of the point set, not
+ *     how much of the object was captured: a sheet (a terrain tile, a wall, a
+ *     floor) fills only the near-equatorial band, so it cannot approach 100%
+ *     however completely it was scanned. Reading it as capture completeness
+ *     turned a complete tile's 56% into a fabricated occlusion report;
  *   - longest dimension — max(L, W, H) of the OBB, the "how big is it"
  *     headline figure capture apps lead with;
  *   - bounding-box surface area — 2(LW + LH + WH) of the OBB, an APPROXIMATE
@@ -43,14 +46,42 @@ export interface ObjectMetrics {
   readonly surfaceAreaM2: number;
   /** Median nearest-neighbour distance (scan resolution). */
   readonly medianSpacingM: number;
-  /** 0..100 — share of viewing directions around the centroid with returns. */
+  /**
+   * 0..100. Share of the 24x12 direction bins around the centroid with
+   * returns. ANGULAR COVERAGE, not capture completeness: the ceiling is set by
+   * the point set's shape, so a sheet-like scan reads low with nothing missing.
+   * The name is kept for compatibility; every label reads "angular coverage".
+   */
   readonly completenessPct: number;
 }
+
+/**
+ * The row labels and per-row qualifiers the on-screen panel and the report PDF
+ * BOTH print, so the two surfaces state the same thing about the same number.
+ * They lived only in ObjectPanel, so the export shipped a bare envelope volume
+ * and a bare bounding surface area with nothing saying what either one is.
+ */
+export const ANGULAR_COVERAGE_LABEL = 'Angular coverage';
+
+/** What the coverage ratio measures, and why a low value is not a defect. */
+export const ANGULAR_COVERAGE_HINT =
+  'Share of the direction bins around the point set’s centroid that have ' +
+  'returns. It follows the shape of the scan: a flat or sheet-like surface fills ' +
+  'only part of the sphere however completely it was captured.';
+
+/** Kept verbatim from the panel: the envelope volume is not a solid volume. */
+export const OBJECT_ENVELOPE_VOLUME_HINT =
+  'Bounding envelope — not a solid volume. A point cloud has no watertight interior.';
+
+/** Kept verbatim from the panel: the surface area is the envelope's skin. */
+export const OBJECT_SURFACE_AREA_HINT =
+  'Bounding-box surface area (approximate) — the envelope’s skin, not the ' +
+  'object’s true (mesh) surface.';
 
 export interface ObjectMetricsParams {
   /** Max points sampled for bounds / PCA. Default 60000. */
   readonly maxSamples?: number;
-  /** Points sampled for the O(n²) spacing/completeness passes. Default 2000. */
+  /** Points sampled for the O(n²) spacing / angular-coverage passes. Default 2000. */
   readonly probeSamples?: number;
   /**
    * Honest source/resident point count when `positions` is itself already a
@@ -256,7 +287,9 @@ export function objectMetrics(
   const medianSpacingM =
     P > 0 && fullCount > P ? probeSpacingM * Math.sqrt(P / fullCount) : probeSpacingM;
 
-  // ── angular completeness — share of direction bins (from centroid) hit ──
+  // ── angular coverage: share of direction bins (from centroid) hit ──
+  // A shape statistic. A sheet occupies the near-equatorial band only, so its
+  // ceiling is well under 100% with nothing missing from the capture.
   const LON = 24, LAT = 12;
   const bins = new Uint8Array(LON * LAT);
   for (let i = 0; i < m; i++) {

--- a/src/terrain/space/spaceReportLayout.ts
+++ b/src/terrain/space/spaceReportLayout.ts
@@ -27,16 +27,33 @@ import {
   sqMetresToSqFeet,
   cubicMetresToCubicFeet,
   resolveLinearUnitScale,
+  magnitudeFixed,
 } from '../spaceMetrics';
-import type { ObjectMetrics } from '../objectMetrics';
+import {
+  type ObjectMetrics,
+  ANGULAR_COVERAGE_LABEL,
+  ANGULAR_COVERAGE_HINT,
+  OBJECT_ENVELOPE_VOLUME_HINT,
+  OBJECT_SURFACE_AREA_HINT,
+} from '../objectMetrics';
 import { SOFTWARE_NAME, NOT_SURVEY_GRADE_NOTE } from '../export/exportProvenance';
-import { evidenceNote } from '../../validation/exportEvidenceNote';
 import { type LinearUnitScale, UNIT_FACTORS } from '../../units/units';
 
-/** One label/value line in a report section. */
+/**
+ * One label/value line in a report section, with the OPTIONAL per-row qualifier
+ * that says what the number is.
+ *
+ * The panel carried those qualifiers as tooltips ("Bounding envelope, not a
+ * solid volume"; "the envelope's skin, not the object's true (mesh) surface")
+ * and the row type had no field for them, so the export printed a bare envelope
+ * volume and a bare bounding surface area with nothing naming either one. The
+ * hint rides the row so both surfaces read from the same string.
+ */
 export interface ReportRow {
   readonly label: string;
   readonly value: string;
+  /** Qualifier printed under the value; single-sourced with the panel. */
+  readonly hint?: string;
 }
 
 /** A titled block of rows. */
@@ -56,14 +73,20 @@ export interface SpaceReportProvenance {
   readonly scanType: string;
   /** 'metres' / 'feet (source) → metres' etc. */
   readonly units: string;
-  /** Points actually measured (the subset the metrics were computed over). */
-  readonly measuredPointCount: number;
+  /**
+   * Points actually measured (the subset the metrics were computed over), or
+   * null when there are no measurements. NEVER 0 as a stand-in for absent: the
+   * no-measurements branch used to render "Points  0 measured / 0 loaded",
+   * which reads as a scan that loaded nothing rather than one not yet measured.
+   */
+  readonly measuredPointCount: number | null;
   /**
    * The LOADED / resident population that subset was drawn from. Never the
    * file's declared total: a display-sampled or still-streaming load holds far
-   * fewer points than the file, so this must not be printed as "source".
+   * fewer points than the file, so this must not be printed as "source". Null
+   * when absent, for the same reason as {@link measuredPointCount}.
    */
-  readonly loadedPointCount: number;
+  readonly loadedPointCount: number | null;
   readonly notSurveyGrade: string;
 }
 
@@ -149,9 +172,9 @@ interface UnitFormat {
   readonly area: (v: Num) => string;
   /** A coarse (rounded) volume. */
   readonly vol: (v: Num) => string;
-  /** A fine (2 dp) area. */
+  /** A fine area, printed at the precision its magnitude supports. */
   readonly areaFine: (v: Num) => string;
-  /** A fine (2 dp) volume. */
+  /** A fine volume, printed at the precision its magnitude supports. */
   readonly volFine: (v: Num) => string;
   /** Mean point spacing. */
   readonly spacing: (v: Num) => string;
@@ -174,8 +197,14 @@ const METRIC_FORMAT: UnitFormat = {
     ok(v)
       ? `${Math.round(v).toLocaleString()} m³ (${Math.round(cubicMetresToCubicFeet(v)).toLocaleString()} ft³)`
       : DASH,
-  areaFine: (v) => (ok(v) ? `${v.toFixed(2)} m² (${sqMetresToSqFeet(v).toFixed(1)} ft²)` : DASH),
-  volFine: (v) => (ok(v) ? `${v.toFixed(2)} m³ (${cubicMetresToCubicFeet(v).toFixed(1)} ft³)` : DASH),
+  areaFine: (v) =>
+    ok(v)
+      ? `${magnitudeFixed(v, 2)} m² (${magnitudeFixed(sqMetresToSqFeet(v), 1)} ft²)`
+      : DASH,
+  volFine: (v) =>
+    ok(v)
+      ? `${magnitudeFixed(v, 2)} m³ (${magnitudeFixed(cubicMetresToCubicFeet(v), 1)} ft³)`
+      : DASH,
   spacing: (v) => (ok(v) ? `${(v * 100).toFixed(1)} cm` : DASH),
   density: (v) => (ok(v) ? `${v.toFixed(1)} pts/m²` : DASH),
 };
@@ -193,8 +222,8 @@ const SOURCE_FORMAT: UnitFormat = {
   len: (v) => (ok(v) ? `${v.toFixed(1)} ${SU}` : DASH),
   area: (v) => (ok(v) ? `${Math.round(v).toLocaleString()} ${SU_SQ}` : DASH),
   vol: (v) => (ok(v) ? `${Math.round(v).toLocaleString()} ${SU_CU}` : DASH),
-  areaFine: (v) => (ok(v) ? `${v.toFixed(2)} ${SU_SQ}` : DASH),
-  volFine: (v) => (ok(v) ? `${v.toFixed(2)} ${SU_CU}` : DASH),
+  areaFine: (v) => (ok(v) ? `${magnitudeFixed(v, 2)} ${SU_SQ}` : DASH),
+  volFine: (v) => (ok(v) ? `${magnitudeFixed(v, 2)} ${SU_CU}` : DASH),
   spacing: (v) => (ok(v) ? `${v.toFixed(3)} ${SU}` : DASH),
   density: (v) => (ok(v) ? `${v.toFixed(1)} pts per square source unit` : DASH),
 };
@@ -333,9 +362,24 @@ function objectContent(input: SpaceReportInput, scale: LinearUnitScale): SpaceRe
         value: f.tripleBare(aabb.lengthM, aabb.widthM, aabb.heightM),
       },
       { label: 'Largest dimension', value: f.len(o.longestDimensionM) },
-      { label: 'Envelope volume', value: f.volFine(o.envelopeVolumeM3) },
-      { label: 'Bounding surface area', value: f.areaFine(o.surfaceAreaM2) },
-      { label: 'Scan completeness', value: `${Math.round(o.completenessPct)}% of directions` },
+      {
+        label: 'Envelope volume',
+        value: f.volFine(o.envelopeVolumeM3),
+        hint: OBJECT_ENVELOPE_VOLUME_HINT,
+      },
+      {
+        label: 'Bounding surface area',
+        value: f.areaFine(o.surfaceAreaM2),
+        hint: OBJECT_SURFACE_AREA_HINT,
+      },
+      // Was "Scan completeness ... % of directions", which read as capture
+      // completeness. The figure bins directions about the centroid, so its
+      // ceiling is the shape of the point set, not how much was captured.
+      {
+        label: ANGULAR_COVERAGE_LABEL,
+        value: `${Math.round(o.completenessPct)}% of directions about the centroid`,
+        hint: ANGULAR_COVERAGE_HINT,
+      },
     ],
   };
   const sections: ReportSection[] = [dims];
@@ -360,8 +404,8 @@ function assemble(
     source: input.name ?? null,
     scanType,
     units: unitsLabel(scale),
-    measuredPointCount: space?.quality.sampledPointCount ?? 0,
-    loadedPointCount: space?.quality.sourcePointCount ?? 0,
+    measuredPointCount: space?.quality.sampledPointCount ?? null,
+    loadedPointCount: space?.quality.sourcePointCount ?? null,
     notSurveyGrade: NOT_SURVEY_GRADE_NOTE,
   };
   return {
@@ -373,6 +417,30 @@ function assemble(
     caveats: space ? [...space.reasons] : [],
   };
 }
+
+/**
+ * The evidence stamp for the space / object report.
+ *
+ * This footer used to print `evidenceNote('MEAS-AREA')`. MEAS-AREA is at
+ * E4_CROSS_IMPLEMENTATION_VALIDATED, so the note took the strong branch and
+ * told the reader the product was "cross-implementation validated against an
+ * independent implementation". MEAS-AREA is the planimetric shoelace area of a
+ * user-drawn polygon, checked against OGR_GEOM_AREA on a planar-polygon
+ * fixture. This report's headline figures are a PCA envelope volume, an
+ * oriented-box surface area, an angular-coverage ratio and a sampled density.
+ * The polygon claim covers none of them.
+ *
+ * No entry in the claim registry does: the VOL- claims are point-sample volumes
+ * measured against a base surface, which is a different estimator again. So the
+ * report makes NO cross-validation claim and states what its figures actually
+ * are. Registering a claim for these products is the way to change this line.
+ */
+export const SPACE_REPORT_EVIDENCE_NOTE =
+  'Evidence: unvalidated envelope estimate. The areas, volumes, angular ' +
+  'coverage and density here are bounding-envelope and grid estimates from the ' +
+  'loaded point sample. No registered claim covers them, so they carry no ' +
+  'cross-implementation and no field validation. Do not present this as a ' +
+  'validated deliverable.';
 
 /** Plain `Key  Value` provenance lines for the report footer. */
 export function spaceProvenanceLines(p: SpaceReportProvenance): string[] {
@@ -389,10 +457,7 @@ export function spaceProvenanceLines(p: SpaceReportProvenance): string[] {
     kv('Units', p.units),
     kv('Points', `${i0(p.measuredPointCount)} measured / ${i0(p.loadedPointCount)} loaded in viewer`),
     kv('Note', p.notSurveyGrade),
-    // Route the space/object report through the ONE evidence gate (PR6): its
-    // dimensional figures sit below their required level, so the report states
-    // the exploratory verdict rather than shipping with no gate stamp.
-    kv('Evidence', evidenceNote('MEAS-AREA')),
+    kv('Evidence', SPACE_REPORT_EVIDENCE_NOTE),
   ];
 }
 

--- a/src/terrain/spaceMetrics.ts
+++ b/src/terrain/spaceMetrics.ts
@@ -33,6 +33,35 @@ export const sqMetresToSqFeet = (a: number): number => a * FT_PER_M * FT_PER_M;
 export const cubicMetresToCubicFeet = (v: number): number => v * FT_PER_M * FT_PER_M * FT_PER_M;
 
 /**
+ * Decimal places for a "fine" area / volume figure, chosen from its MAGNITUDE.
+ *
+ * The object rows used two decimals unconditionally because a compact scan is
+ * routinely under 1 m2 / 1 m3, where integer rounding erases the figure. Applied
+ * to a 333,151,984 m3 bounding envelope derived from a 59k-point sample, the
+ * same rule printed ten significant figures and claimed a cubic-centimetre
+ * resolution the estimate does not have.
+ */
+function fineDecimals(v: number): number {
+  const a = Math.abs(v);
+  if (a < 100) return 2;
+  if (a < 10_000) return 1;
+  return 0;
+}
+
+/**
+ * A fine figure printed at the decimal count its magnitude supports, capped at
+ * `maxDecimals` (2 for the metre column, 1 for the foot column, matching what
+ * those columns have always printed at object scale). At zero decimals the
+ * figure groups its thousands like the coarse rows.
+ *
+ * Only the printed digits change. The VALUE is the caller's, untouched.
+ */
+export function magnitudeFixed(v: number, maxDecimals: number): string {
+  const d = Math.min(maxDecimals, fineDecimals(v));
+  return d === 0 ? Math.round(v).toLocaleString() : v.toFixed(d);
+}
+
+/**
  * L × W × H, in metres. Length ≥ width, height vertical.
  *
  * L and W are the sides of the minimum-area rectangle around the horizontal

--- a/src/ui/ObjectPanel.ts
+++ b/src/ui/ObjectPanel.ts
@@ -8,18 +8,26 @@
  *   - interior → a room report: dimensions, floor area, ceiling height,
  *     enclosed volume, floor/wall/ceiling planes, storeys, capture quality;
  *   - object   → the object measurements (oriented box, envelope volume, scan
- *     resolution, completeness) plus capture quality.
+ *     resolution, angular coverage) plus capture quality.
  *
  * Both surface honest caveats and an escape hatch to run the terrain pipeline
  * anyway if the auto-detector got it wrong.
  */
 
-import type { ObjectMetrics } from '../terrain/objectMetrics';
+import {
+  type ObjectMetrics,
+  type BoxDims,
+  ANGULAR_COVERAGE_LABEL,
+  ANGULAR_COVERAGE_HINT,
+  OBJECT_ENVELOPE_VOLUME_HINT,
+  OBJECT_SURFACE_AREA_HINT,
+} from '../terrain/objectMetrics';
 import type { SpaceMetrics } from '../terrain/spaceMetrics';
 import {
   metresToFeet,
   sqMetresToSqFeet,
   cubicMetresToCubicFeet,
+  magnitudeFixed,
 } from '../terrain/spaceMetrics';
 import type { ScanShape, SpaceKind } from '../terrain/scanShape';
 import type { ScanTypeOverride } from '../terrain/scanRoute';
@@ -113,12 +121,35 @@ const areaMft = (v: number): string =>
 const volMft = (v: number): string =>
   Number.isFinite(v) ? `${Math.round(v).toLocaleString()} m³ (${Math.round(cubicMetresToCubicFeet(v)).toLocaleString()} ft³)` : '—';
 // Object-scale variants — compact scans are routinely < 1 m² / < 1 m³, where
-// the interior path's integer rounding would erase the figure, so keep two
-// decimals in metres while reusing the same exact metre→foot conversions.
+// the interior path's integer rounding would erase the figure. The precision
+// follows the MAGNITUDE (magnitudeFixed): two decimals keep a sub-cubic-metre
+// object readable, and a hundred-million-cubic-metre envelope stops claiming
+// centimetre resolution it never had. Same exact metre→foot conversions.
 const areaMftFine = (v: number): string =>
-  Number.isFinite(v) ? `${v.toFixed(2)} m² (${sqMetresToSqFeet(v).toFixed(1)} ft²)` : '—';
+  Number.isFinite(v)
+    ? `${magnitudeFixed(v, 2)} m² (${magnitudeFixed(sqMetresToSqFeet(v), 1)} ft²)`
+    : '—';
 const volMftFine = (v: number): string =>
-  Number.isFinite(v) ? `${v.toFixed(2)} m³ (${cubicMetresToCubicFeet(v).toFixed(1)} ft³)` : '—';
+  Number.isFinite(v)
+    ? `${magnitudeFixed(v, 2)} m³ (${magnitudeFixed(cubicMetresToCubicFeet(v), 1)} ft³)`
+    : '—';
+
+/**
+ * True when the scan is a SHEET: its shortest oriented-box side is a small
+ * fraction of its longest.
+ *
+ * Angular coverage bins directions about the centroid, so a single-sided
+ * surface (a terrain tile, a wall, a floor) fills only the near-equatorial band
+ * and cannot approach 100% however completely it was captured. The field case
+ * is a 1270 x 977 x 268 m terrain tile: a ratio of 0.21, reporting 56% with
+ * nothing missing. Below the threshold the occlusion warning can never be
+ * cleared, so it is not shown at all.
+ */
+const SHEET_ASPECT = 0.25;
+export function isSheetLikeScan(obb: BoxDims): boolean {
+  const { lengthM: L, heightM: H } = obb;
+  return Number.isFinite(L) && Number.isFinite(H) && L > 0 && H / L < SHEET_ASPECT;
+}
 
 export class ObjectPanel {
   readonly element: HTMLElement;
@@ -198,8 +229,11 @@ export class ObjectPanel {
   private _quality(q: SpaceMetrics['quality']): void {
     this._body.append(
       el('div', { className: 'olv-object-subhead', text: 'Capture quality' }),
-      this._row('Points (used · source)', `${i0(q.sampledPointCount)} · ${i0(q.sourcePointCount)}`,
-        'Points used for this analysis and the total they were sampled from.'),
+      // Named exactly as the report names them (spaceReportLayout
+      // captureSection). The second number is the LOADED / resident population,
+      // not the file's declared total, so neither surface calls it "source".
+      this._row('Points (measured / loaded)', `${i0(q.sampledPointCount)} · ${i0(q.sourcePointCount)}`,
+        'Points measured for this analysis and the loaded population they were sampled from.'),
       this._row('Density · spacing', `${q.densityPerM2.toFixed(1)} pts/m² · ~${cm(q.meanSpacingM)}`,
         'Approximate areal density and mean point spacing.'),
       // HONESTY: coveragePct is occupied-cells / (cols*rows) over the scan's
@@ -544,14 +578,19 @@ export class ObjectPanel {
         `${m1(a.lengthM)} × ${m1(a.widthM)} × ${m1(a.heightM)} m`,
         `${metresToFeet(a.lengthM).toFixed(1)} × ${metresToFeet(a.widthM).toFixed(1)} × ${metresToFeet(a.heightM).toFixed(1)} ft — box aligned to the scan axes.`),
       this._row('Envelope volume', volMftFine(metrics.envelopeVolumeM3),
-        'Bounding envelope — not a solid volume. A point cloud has no watertight interior.'),
+        OBJECT_ENVELOPE_VOLUME_HINT),
       this._row('Bounding surface area', areaMftFine(metrics.surfaceAreaM2),
-        'Bounding-box surface area (approximate) — the envelope’s skin, not the object’s true (mesh) surface.'),
+        OBJECT_SURFACE_AREA_HINT),
       this._row('Points · spacing', `${metrics.pointCount.toLocaleString()} · ~${cm(metrics.medianSpacingM)}`),
-      this._row('Scan completeness', `${Math.round(metrics.completenessPct)}% of directions`,
-        'Share of viewing directions around the object that have returns.'),
+      // Was "Scan completeness", which read as capture completeness. The ratio
+      // bins directions about the centroid, so its ceiling is the shape of the
+      // point set, not how much of the object was scanned.
+      this._row(ANGULAR_COVERAGE_LABEL, `${Math.round(metrics.completenessPct)}% of directions`,
+        ANGULAR_COVERAGE_HINT),
     );
-    if (metrics.completenessPct < 65) {
+    // Only a scan that COULD reach full angular coverage can be short of it. A
+    // sheet never can, so warning about its underside invents a capture defect.
+    if (metrics.completenessPct < 65 && !isSheetLikeScan(metrics.obb)) {
       this._body.append(el('div', {
         className: 'olv-object-note is-warn',
         text: 'Parts of the surface (often the underside / occluded sides) were not captured.',

--- a/tests/objectPanelSpace.test.ts
+++ b/tests/objectPanelSpace.test.ts
@@ -259,3 +259,103 @@ describe('ObjectPanel — space / object routing', () => {
     expect(all.some((e) => e.className.includes('olv-object-run-anyway'))).toBe(true);
   });
 });
+
+// ── Angular coverage is a shape signature, not a capture defect ─────────────
+// The panel warned "Parts of the surface (often the underside / occluded sides)
+// were not captured." below 65%. A sheet-like scan bins into the near-equatorial
+// band only, so it can never clear 65% however completely it was captured, and
+// the warning fabricated a defect report for a complete tile.
+describe('ObjectPanel - the occlusion warning is gated on shape', () => {
+  const OCCLUSION_WARNING = 'Parts of the surface';
+
+  /** Hand-built metrics: the gate is about labels, never the computation. */
+  function box(L: number, W: number, H: number, coveragePct: number): {
+    pointCount: number;
+    obb: { lengthM: number; widthM: number; heightM: number };
+    aabb: { lengthM: number; widthM: number; heightM: number };
+    longestDimensionM: number;
+    envelopeVolumeM3: number;
+    surfaceAreaM2: number;
+    medianSpacingM: number;
+    completenessPct: number;
+  } {
+    return {
+      pointCount: 59_029,
+      obb: { lengthM: L, widthM: W, heightM: H },
+      aabb: { lengthM: L, widthM: W, heightM: H },
+      longestDimensionM: L,
+      envelopeVolumeM3: L * W * H,
+      surfaceAreaM2: 2 * (L * W + L * H + W * H),
+      medianSpacingM: 0.42,
+      completenessPct: coveragePct,
+    };
+  }
+
+  it('a sheet-like scan at 56% gets no occlusion warning', async () => {
+    const { ObjectPanel } = await import('../src/ui/ObjectPanel');
+    const panel = new ObjectPanel();
+    // The field case: a 1270 x 977 x 268 m terrain tile reporting 56%.
+    panel.showObject(box(1270.87, 977.35, 268.22, 56), null, null);
+    const text = (panel.element as unknown as FakeEl).textContent;
+    expect(text).not.toContain(OCCLUSION_WARNING);
+  });
+
+  it('a compact object that really is short of returns still gets it', async () => {
+    const { ObjectPanel } = await import('../src/ui/ObjectPanel');
+    const panel = new ObjectPanel();
+    panel.showObject(box(1.2, 1.1, 0.9, 41), null, null);
+    const text = (panel.element as unknown as FakeEl).textContent;
+    expect(text).toContain(OCCLUSION_WARNING);
+  });
+
+  it('names the row angular coverage, never a completeness', async () => {
+    const { ObjectPanel } = await import('../src/ui/ObjectPanel');
+    const { ANGULAR_COVERAGE_LABEL } = await import('../src/terrain/objectMetrics');
+    const panel = new ObjectPanel();
+    panel.showObject(box(1.2, 1.1, 0.9, 88), null, null);
+    const text = (panel.element as unknown as FakeEl).textContent;
+    expect(text).toContain(ANGULAR_COVERAGE_LABEL);
+    expect(text).not.toMatch(/completeness/i);
+  });
+});
+
+// ── One name for the two point populations ─────────────────────────────────
+// The report says "measured / loaded"; the panel still said "used / source",
+// and "source" invited the reader to treat a display sample as the whole file.
+describe('ObjectPanel - point populations are named as the report names them', () => {
+  function room2(W = 14, D = 29, H = 5, step = 0.5): Float32Array {
+    const t: number[] = [];
+    const push = (x: number, y: number, z: number): void => { t.push(x, y, z); };
+    for (let x = 0; x <= W; x += step)
+      for (let y = 0; y <= D; y += step) { push(x, y, 0); push(x, y, H); }
+    for (let z = 0; z <= H; z += step)
+      for (let x = 0; x <= W; x += step) { push(x, 0, z); push(x, D, z); }
+    for (let z = 0; z <= H; z += step)
+      for (let y = 0; y <= D; y += step) { push(0, y, z); push(W, y, z); }
+    return Float32Array.from(t);
+  }
+
+  it('uses the report label verbatim and never calls the loaded sample "source"', async () => {
+    const { ObjectPanel } = await import('../src/ui/ObjectPanel');
+    const { spaceMetrics } = await import('../src/terrain/spaceMetrics');
+    const { classifyScanShape } = await import('../src/terrain/scanShape');
+    const { buildSpaceReportContent } = await import(
+      '../src/terrain/space/spaceReportLayout'
+    );
+    const pos = room2();
+    const shape = classifyScanShape(pos);
+    const space = spaceMetrics(pos, {
+      upAxis: shape.up, spaceKind: 'interior', sourcePointCount: 1_888_921,
+    });
+    const reportLabel = buildSpaceReportContent({ space, name: 'Populations' })
+      .sections.flatMap((s) => s.rows)
+      .find((r) => r.label.startsWith('Points'))!.label;
+
+    const panel = new ObjectPanel();
+    panel.showSpace(space, shape);
+    const text = (panel.element as unknown as FakeEl).textContent;
+    expect(text).toContain(reportLabel);
+    expect(text).toMatch(/measured/i);
+    expect(text).not.toContain('Points (used');
+  });
+});

--- a/tests/spaceReportLayout.test.ts
+++ b/tests/spaceReportLayout.test.ts
@@ -10,9 +10,17 @@ import { describe, it, expect } from 'vitest';
 import { buildSpaceReportContent } from '../src/terrain/space/spaceReportLayout';
 import { knownUnit, unknownUnit } from '../src/units/units';
 import { spaceMetrics } from '../src/terrain/spaceMetrics';
-import { objectMetrics } from '../src/terrain/objectMetrics';
 import { classifyScanShape } from '../src/terrain/scanShape';
 import { NOT_SURVEY_GRADE_NOTE } from '../src/terrain/export/exportProvenance';
+import { evidenceNote } from '../src/validation/exportEvidenceNote';
+import {
+  objectMetrics,
+  ANGULAR_COVERAGE_LABEL,
+  ANGULAR_COVERAGE_HINT,
+  OBJECT_ENVELOPE_VOLUME_HINT,
+  OBJECT_SURFACE_AREA_HINT,
+  type ObjectMetrics,
+} from '../src/terrain/objectMetrics';
 
 function room(W = 14, D = 29, H = 5, step = 0.5): Float32Array {
   const t: number[] = [];
@@ -108,7 +116,7 @@ describe('buildSpaceReportContent — object', () => {
     const text = allText(content);
     for (const field of [
       'Sculpture', 'Oriented', 'Axis-aligned', 'Largest dimension',
-      'Envelope volume', 'Bounding surface area', 'Scan completeness', 'Capture quality',
+      'Envelope volume', 'Bounding surface area', 'Angular coverage', 'Capture quality',
     ]) {
       expect(text, `missing "${field}"`).toContain(field);
     }
@@ -341,5 +349,171 @@ describe('buildSpaceReportContent — point populations are named honestly', () 
     const notes = content.caveats.join(' | ');
     expect(notes).not.toContain('full 1,888,921-point scan');
     expect(notes).not.toMatch(/full [\d,]+-point scan/);
+  });
+});
+
+// ── The report may only claim what it actually measures ─────────────────────
+// The footer stamped `evidenceNote('MEAS-AREA')`, and MEAS-AREA is E4, so the
+// space report printed "cross-implementation validated against an independent
+// implementation" over a PCA envelope volume, an oriented-box surface area, an
+// angular-coverage ratio and a sampled density. MEAS-AREA is the shoelace area
+// of a user polygon; it covers none of those figures.
+describe('buildSpaceReportContent - evidence claim matches the product', () => {
+  const obj = cubeShell();
+  const content = buildSpaceReportContent({
+    space: spaceMetrics(obj, {
+      upAxis: 'z', spaceKind: 'object', hasRgb: true, unitToMetres: 1, unitKnown: true,
+    }),
+    object: objectMetrics(obj),
+    name: 'Claim',
+  });
+  const evidenceLine = (): string =>
+    content.provenanceLines.find((l) => l.startsWith('Evidence'))!;
+
+  it('still stamps an Evidence line', () => {
+    expect(evidenceLine()).toBeDefined();
+  });
+
+  it('never asserts cross-implementation or independent-implementation validation', () => {
+    const line = evidenceLine();
+    // The MEAS-AREA strong branch, in both of its affirmative shapes.
+    expect(line).not.toMatch(/cross-implementation validated/i);
+    expect(line).not.toMatch(/validated against an independent implementation/i);
+    expect(line).not.toMatch(/\bfield-validated\b/i);
+    // What it says instead: the absence of both, stated outright.
+    expect(line).toMatch(/no cross-implementation/i);
+  });
+
+  it('is not the MEAS-AREA polygon note', () => {
+    expect(evidenceLine()).not.toContain(evidenceNote('MEAS-AREA'));
+  });
+
+  it('says plainly that the figures are unvalidated envelope estimates', () => {
+    const line = evidenceLine();
+    expect(line).toMatch(/unvalidated/i);
+    expect(line).toMatch(/envelope/i);
+  });
+});
+
+// ── "Scan completeness" measured angular coverage, not capture completeness ──
+// 24x12 direction bins about the centroid: a sheet occupies only the
+// near-equatorial band, so the ratio is a shape signature, not missing data.
+describe('buildSpaceReportContent - the coverage row is named for what it measures', () => {
+  const obj = cubeShell();
+  const rows = buildSpaceReportContent({
+    space: spaceMetrics(obj, {
+      upAxis: 'z', spaceKind: 'object', hasRgb: true, unitToMetres: 1, unitKnown: true,
+    }),
+    object: objectMetrics(obj),
+    name: 'Coverage',
+  }).sections.flatMap((s) => s.rows);
+
+  it('no row calls the ratio a completeness', () => {
+    for (const r of rows) {
+      expect(`${r.label} ${r.value} ${r.hint ?? ''}`).not.toMatch(/completeness/i);
+    }
+  });
+
+  it('names it angular coverage about the centroid', () => {
+    const row = rows.find((r) => r.label === ANGULAR_COVERAGE_LABEL);
+    expect(row, 'angular-coverage row missing').toBeDefined();
+    expect(row!.value).toMatch(/%/);
+    expect(row!.hint).toBe(ANGULAR_COVERAGE_HINT);
+  });
+});
+
+// ── Per-row qualifiers must survive into the PDF content model ──────────────
+// The panel disclosed "Bounding envelope, not a solid volume" and "the
+// envelope's skin, not the object's true (mesh) surface"; ReportRow had no
+// hint field, so neither reached the export.
+describe('buildSpaceReportContent - envelope rows carry their qualifier', () => {
+  const obj = cubeShell();
+  const rows = buildSpaceReportContent({
+    space: spaceMetrics(obj, {
+      upAxis: 'z', spaceKind: 'object', hasRgb: true, unitToMetres: 1, unitKnown: true,
+    }),
+    object: objectMetrics(obj),
+    name: 'Qualifiers',
+  }).sections.flatMap((s) => s.rows);
+
+  it('envelope volume states it is not a solid volume', () => {
+    const row = rows.find((r) => r.label === 'Envelope volume')!;
+    expect(row.hint).toBe(OBJECT_ENVELOPE_VOLUME_HINT);
+    expect(row.hint).toMatch(/not a solid volume/);
+  });
+
+  it('bounding surface area states it is the envelope skin, not a mesh surface', () => {
+    const row = rows.find((r) => r.label === 'Bounding surface area')!;
+    expect(row.hint).toBe(OBJECT_SURFACE_AREA_HINT);
+    expect(row.hint).toMatch(/skin/);
+  });
+});
+
+// ── Printed precision follows the magnitude ─────────────────────────────────
+// Two decimals unconditionally put ten significant figures on a 333 million m3
+// envelope derived from a 59k-point sample.
+describe('buildSpaceReportContent - fine precision follows the magnitude', () => {
+  const shell = cubeShell();
+  const metricSpace = spaceMetrics(shell, {
+    upAxis: 'z', spaceKind: 'object', hasRgb: true, unitToMetres: 1, unitKnown: true,
+  });
+  const box = (L: number, W: number, H: number, pointCount: number): ObjectMetrics => ({
+    pointCount,
+    obb: { lengthM: L, widthM: W, heightM: H },
+    aabb: { lengthM: L, widthM: W, heightM: H },
+    longestDimensionM: L,
+    envelopeVolumeM3: L * W * H,
+    surfaceAreaM2: 2 * (L * W + L * H + W * H),
+    medianSpacingM: 0.42,
+    completenessPct: 56,
+  });
+  const valueOf = (object: ObjectMetrics, label: string): string =>
+    buildSpaceReportContent({ space: metricSpace, object, name: 'Precision' })
+      .sections.flatMap((s) => s.rows)
+      .find((r) => r.label === label)!.value;
+
+  // The field case: a 1270 x 977 x 268 m terrain envelope over a 59k sample.
+  const huge = box(1270.87, 977.35, 268.22, 59_029);
+  // A compact object scan, where two decimals are the whole figure.
+  const small = box(1, 0.7, 0.6, 41_000);
+
+  it('a hundred-million-cubic-metre envelope prints no decimals', () => {
+    const v = valueOf(huge, 'Envelope volume');
+    expect(v).toContain('333,151,984');
+    expect(v).not.toMatch(/\d\.\d\d\s*m³/);
+  });
+
+  it('a large bounding surface area prints no decimals either', () => {
+    const v = valueOf(huge, 'Bounding surface area');
+    expect(v).toContain('3,690,205');
+    expect(v).not.toMatch(/\d\.\d\d\s*m²/);
+  });
+
+  it('a sub-cubic-metre object still keeps two decimals', () => {
+    expect(valueOf(small, 'Envelope volume')).toMatch(/^0\.42 m³/);
+  });
+
+  it('the VALUE is unchanged, only the printed digits', () => {
+    // 0.42 m3 rounds to 0 at zero decimals; the small branch must not.
+    expect(valueOf(small, 'Envelope volume')).not.toMatch(/^0 m³/);
+  });
+});
+
+// ── The provenance footer must not fabricate zeros ──────────────────────────
+// `space?.quality.sampledPointCount ?? 0` rendered "Points  0 measured /
+// 0 loaded" for the no-measurements branch, against the file's own rule that an
+// absent value reads as a dash.
+describe('buildSpaceReportContent - absent counts are dashes, never zeros', () => {
+  const content = buildSpaceReportContent({ space: null, name: 'Empty' });
+
+  it('carries null counts rather than fabricated zeros', () => {
+    expect(content.provenance.measuredPointCount).toBeNull();
+    expect(content.provenance.loadedPointCount).toBeNull();
+  });
+
+  it('renders the Points line with dashes', () => {
+    const line = content.provenanceLines.find((l) => l.startsWith('Points'))!;
+    expect(line).toContain('—');
+    expect(line).not.toMatch(/\b0\b/);
   });
 });

--- a/tests/spaceReportPdf.test.ts
+++ b/tests/spaceReportPdf.test.ts
@@ -143,4 +143,23 @@ describe('buildSpaceReportPdf', () => {
     });
     expect(isPdf(bytes)).toBe(true);
   });
+
+  it('prints the per-row envelope qualifiers on the page', async () => {
+    // The panel disclosed "not a solid volume" and "the envelope's skin"; the
+    // PDF carried neither, so the export read as if the two figures were plain
+    // measurements. Both qualifiers must reach the page.
+    const pos = cubeShell();
+    const space = spaceMetrics(pos, { upAxis: 'z', spaceKind: 'object', hasRgb: false });
+    const bytes = await buildSpaceReportPdf({
+      space,
+      object: objectMetrics(pos),
+      name: 'Sculpture',
+      softwareVersion: '0.4.3',
+      metricVersion: 'v0.4.1',
+    });
+    const page = (await extractTextOps(bytes)).map((o) => o.text).join(' ');
+    expect(page).toContain('not a solid volume');
+    expect(page).toContain("envelope's skin");
+    expect(page).not.toMatch(/completeness/i);
+  });
 });


### PR DESCRIPTION
The space report claimed cross-implementation validation it had no basis for, and labelled a shape metric as a capture defect.

`evidenceNote('MEAS-AREA')` printed the E4 sentence for a PCA envelope volume, an oriented-box surface area, an angular ratio and a sampled density. `MEAS-AREA` covers polygon area; no registered claim covers these, so the report now states plainly that they are unvalidated envelope estimates. No registry entry was added and no level changed.

"Scan completeness" becomes "Angular coverage", since a flat sheet cannot exceed roughly half however completely it was captured, and the occlusion warning is gated so a sheet-like scan no longer receives a defect report it can never clear. Envelope volume and surface area now carry their qualifiers into the PDF, and absent counts render as a dash rather than zero.
