### PR TITLE
fix(measure): normalise object metrics to metres before measuring

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -120,7 +120,7 @@ import {
   type ScanTypeOverride,
 } from './terrain/scanRoute';
 import { objectMetrics, type ObjectMetrics } from './terrain/objectMetrics';
-import { spaceMetrics, type SpaceMetrics } from './terrain/spaceMetrics';
+import { spaceMetrics, resolveLinearUnitScale, positionsInMetres, type SpaceMetrics } from './terrain/spaceMetrics';
 import { TERRAIN_METRIC_VERSION } from './terrain/datasetIntelligence';
 import { ExportPanel } from './ui/ExportPanel';
 import { makeLocalToLonLat } from './export/lonLatMapper';
@@ -3121,11 +3121,11 @@ function applyScanRoute(initial: boolean, settled = false): boolean {
       ? streamingCloud.availableColorModes().includes('rgb')
       : !!(activeCloud && activeCloud.colors && activeCloud.colors.length > 0);
     // Compute REAL metrics for the EFFECTIVE type — when forced, the report
-    // reflects what's actually there for that interpretation; nothing fabricated.
-    // The active scan's context, so a foot-based CRS reports honest metre/feet
-    // dimensions from the same object the terrain core reads.
+    // reflects what's actually there; nothing fabricated. The active scan's
+    // context makes a foot CRS report honest metre/feet dimensions.
     const spaceCtx = crsService.context();
     const unitToMetres = spaceCtx.linearUnitToMetres;
+    const objectScale = resolveLinearUnitScale(unitToMetres, spaceCtx.linearUnitKnown);
     const space = spaceMetrics(gathered.positions, {
       upAxis: shape.up,
       spaceKind: effective === 'interior' ? 'interior' : 'object',
@@ -3138,12 +3138,12 @@ function applyScanRoute(initial: boolean, settled = false): boolean {
       residentOnly: gathered.residentOnly,
     });
     const spaceKind: 'interior' | 'object' = effective === 'interior' ? 'interior' : 'object';
-    // Same stride honesty as spaceMetrics above: the gather caps at 60 k, so
-    // the spacing probe must be corrected against the SCAN's resident count or
-    // the reported resolution describes the subsample (√(N/P) too coarse).
+    // Same stride honesty as spaceMetrics above (the gather caps at 60 k), and
+    // the SAME unit authority: a known foot CRS is scaled to metres before the
+    // measurement runs, while an unknown unit stays in the file's own units.
     const object =
       spaceKind === 'object'
-        ? objectMetrics(gathered.positions, { sourcePointCount: gathered.totalPoints })
+        ? objectMetrics(positionsInMetres(gathered.positions, objectScale), { sourcePointCount: gathered.totalPoints })
         : null;
     // Track the content for hydration; apply now (no-op if not yet mounted).
     if (spaceKind === 'interior') {

--- a/src/terrain/sourceScale.ts
+++ b/src/terrain/sourceScale.ts
@@ -1,0 +1,41 @@
+/**
+ * sourceScale.ts
+ *
+ * ONE implementation of "put these coordinates in metres".
+ *
+ * Two seams need it: `spaceMetrics` (which measures an object's envelope volume
+ * through `objectMetrics`) and the Object-panel host in `main.ts` (which calls
+ * `objectMetrics` directly). The host used to pass RAW source coordinates, so a
+ * foot CRS produced foot dimensions, foot spacing, square-foot areas and cubic
+ * foot volumes, all printed and exported as metres. Both call sites now scale
+ * through the helpers here, so the two can never drift apart.
+ */
+
+import type { LinearUnitScale } from '../units/units';
+
+/** Copy `positions` with every component multiplied by `s`. */
+export function scalePositions(
+  positions: Float32Array | ReadonlyArray<number>,
+  s: number,
+): Float32Array {
+  const out = new Float32Array(positions.length);
+  for (let i = 0; i < positions.length; i++) out[i] = positions[i] * s;
+  return out;
+}
+
+/**
+ * Positions expressed in metres when the linear unit is KNOWN, and untouched
+ * when it is not.
+ *
+ * An unknown unit is not a licence to assume metres: the coordinates stay in
+ * the file's own units and the presentation layer reads the same
+ * {@link LinearUnitScale} to drop every metre, foot and centimetre claim. A
+ * known factor of exactly 1 is a declared metre CRS, so no copy is made.
+ */
+export function positionsInMetres(
+  positions: Float32Array | ReadonlyArray<number>,
+  scale: LinearUnitScale,
+): Float32Array | ReadonlyArray<number> {
+  if (!scale.known || scale.metresPerUnit === 1) return positions;
+  return scalePositions(positions, scale.metresPerUnit);
+}

--- a/src/terrain/spaceMetrics.ts
+++ b/src/terrain/spaceMetrics.ts
@@ -22,6 +22,10 @@
 
 import { footprintRect, type Axis } from './scanShape';
 import { objectMetrics } from './objectMetrics';
+import { scalePositions } from './sourceScale';
+// Re-exported so the Object-panel host reaches the ONE scaling implementation
+// through the module that already owns the unit resolution.
+export { positionsInMetres } from './sourceScale';
 import { type LinearUnitScale, knownUnit, unknownUnit } from '../units/units';
 import { denseFootprintBbox } from './space/floorplan/wallSlice';
 
@@ -593,7 +597,7 @@ export function spaceMetrics(
     enclosedVolumeM3 = floorAreaM2 * ceilingHeightM;
   } else if (spaceKind === 'object') {
     // Open object: fall back to the OBB envelope volume (in metres).
-    const om = objectMetrics(u2m === 1 ? positions : scaleCopy(positions, u2m), { maxSamples });
+    const om = objectMetrics(u2m === 1 ? positions : scalePositions(positions, u2m), { maxSamples });
     enclosedVolumeM3 = om.envelopeVolumeM3 > 0 ? om.envelopeVolumeM3 : dims.lengthM * dims.widthM * dims.heightM;
   } else {
     enclosedVolumeM3 = null;
@@ -643,11 +647,4 @@ export function spaceMetrics(
     },
     storyCount, quality, linearUnit, reasons,
   };
-}
-
-/** Copy positions scaled by `s` (only used when a unit conversion is needed). */
-function scaleCopy(positions: Float32Array | ReadonlyArray<number>, s: number): Float32Array {
-  const out = new Float32Array(positions.length);
-  for (let i = 0; i < positions.length; i++) out[i] = positions[i] * s;
-  return out;
 }

--- a/src/ui/ObjectPanel.ts
+++ b/src/ui/ObjectPanel.ts
@@ -16,7 +16,6 @@
 
 import {
   type ObjectMetrics,
-  type BoxDims,
   ANGULAR_COVERAGE_LABEL,
   ANGULAR_COVERAGE_HINT,
   OBJECT_ENVELOPE_VOLUME_HINT,
@@ -135,21 +134,59 @@ const volMftFine = (v: number): string =>
     : '—';
 
 /**
- * True when the scan is a SHEET: its shortest oriented-box side is a small
- * fraction of its longest.
+ * The unit-dependent value formatters for the OBJECT report, chosen once from
+ * the scale the metrics were computed under.
  *
- * Angular coverage bins directions about the centroid, so a single-sided
- * surface (a terrain tile, a wall, a floor) fills only the near-equatorial band
- * and cannot approach 100% however completely it was captured. The field case
- * is a 1270 x 977 x 268 m terrain tile: a ratio of 0.21, reporting 56% with
- * nothing missing. Below the threshold the occlusion warning can never be
- * cleared, so it is not shown at all.
+ * The panel used to stamp " m", " ft" and " cm" on every figure regardless of
+ * the source frame. Two defects rode on that: a foot CRS was measured in feet
+ * and labelled metres, and a scan whose linear unit never resolved was labelled
+ * metres on nothing at all. The host now normalises KNOWN units to metres
+ * before measuring; an UNKNOWN unit stays in the file's own units, and this
+ * record drops the metric suffixes and the foot conversion for it. Same
+ * approach as the report layout's UnitFormat (spaceReportLayout.ts).
  */
-const SHEET_ASPECT = 0.25;
-export function isSheetLikeScan(obb: BoxDims): boolean {
-  const { lengthM: L, heightM: H } = obb;
-  return Number.isFinite(L) && Number.isFinite(H) && L > 0 && H / L < SHEET_ASPECT;
+interface ObjectUnitFormat {
+  /** L x W x H, the row value. */
+  readonly triple: (l: number, w: number, h: number) => string;
+  /** The row hint's leading conversion, empty when there is none. */
+  readonly tripleHint: (l: number, w: number, h: number) => string;
+  /** A single length. */
+  readonly len: (v: number) => string;
+  /** A fine area. */
+  readonly areaFine: (v: number) => string;
+  /** A fine volume. */
+  readonly volFine: (v: number) => string;
+  /** Mean / median point spacing. */
+  readonly spacing: (v: number) => string;
+  /** Areal point density. */
+  readonly density: (v: number) => string;
 }
+
+/** Source-unit qualifiers: dimensionality without a metre claim. */
+const SU = '(source units)';
+const SU_SQ = '(square source units)';
+const SU_CU = '(cubic source units)';
+
+const METRIC_FORMAT: ObjectUnitFormat = {
+  triple: (l, w, h) => `${m1(l)} × ${m1(w)} × ${m1(h)} m`,
+  tripleHint: (l, w, h) =>
+    `${metresToFeet(l).toFixed(1)} × ${metresToFeet(w).toFixed(1)} × ${metresToFeet(h).toFixed(1)} ft — `,
+  len: mft,
+  areaFine: areaMftFine,
+  volFine: volMftFine,
+  spacing: cm,
+  density: (v) => (Number.isFinite(v) ? `${v.toFixed(1)} pts/m²` : '—'),
+};
+
+const SOURCE_FORMAT: ObjectUnitFormat = {
+  triple: (l, w, h) => `${m1(l)} × ${m1(w)} × ${m1(h)}  ${SU}`,
+  tripleHint: () => '',
+  len: (v) => (Number.isFinite(v) ? `${v.toFixed(1)} ${SU}` : '—'),
+  areaFine: (v) => (Number.isFinite(v) ? `${magnitudeFixed(v, 2)} ${SU_SQ}` : '—'),
+  volFine: (v) => (Number.isFinite(v) ? `${magnitudeFixed(v, 2)} ${SU_CU}` : '—'),
+  spacing: (v) => (Number.isFinite(v) ? `${v.toFixed(3)} ${SU}` : '—'),
+  density: (v) => (Number.isFinite(v) ? `${v.toFixed(1)} pts per square source unit` : '—'),
+};
 
 export class ObjectPanel {
   readonly element: HTMLElement;
@@ -226,7 +263,7 @@ export class ObjectPanel {
     ]);
   }
 
-  private _quality(q: SpaceMetrics['quality']): void {
+  private _quality(q: SpaceMetrics['quality'], f: ObjectUnitFormat = METRIC_FORMAT): void {
     this._body.append(
       el('div', { className: 'olv-object-subhead', text: 'Capture quality' }),
       // Named exactly as the report names them (spaceReportLayout
@@ -234,7 +271,7 @@ export class ObjectPanel {
       // not the file's declared total, so neither surface calls it "source".
       this._row('Points (measured / loaded)', `${i0(q.sampledPointCount)} · ${i0(q.sourcePointCount)}`,
         'Points measured for this analysis and the loaded population they were sampled from.'),
-      this._row('Density · spacing', `${q.densityPerM2.toFixed(1)} pts/m² · ~${cm(q.meanSpacingM)}`,
+      this._row('Density · spacing', `${f.density(q.densityPerM2)} · ~${f.spacing(q.meanSpacingM)}`,
         'Approximate areal density and mean point spacing.'),
       // HONESTY: coveragePct is occupied-cells / (cols*rows) over the scan's
       // axis-aligned BOUNDING-BOX grid (spaceMetrics.ts) — a fill ratio of the
@@ -568,36 +605,31 @@ export class ObjectPanel {
     }
     const o = metrics.obb;
     const a = metrics.aabb;
+    // The scale the figures were COMPUTED under, straight off the metrics the
+    // CRS authority produced. A known unit was normalised to metres before
+    // measuring; an unknown one was left in source units and is labelled so.
+    // No space metrics (the back-compat shim) keeps the legacy metric render.
+    const f = space && !space.linearUnit.known ? SOURCE_FORMAT : METRIC_FORMAT;
     this._body.append(
-      this._row('Dimensions (oriented)',
-        `${m1(o.lengthM)} × ${m1(o.widthM)} × ${m1(o.heightM)} m`,
-        `${metresToFeet(o.lengthM).toFixed(1)} × ${metresToFeet(o.widthM).toFixed(1)} × ${metresToFeet(o.heightM).toFixed(1)} ft — tight box from the object’s own principal axes.`),
-      this._row('Largest dimension', mft(metrics.longestDimensionM),
+      this._row('Dimensions (oriented)', f.triple(o.lengthM, o.widthM, o.heightM),
+        `${f.tripleHint(o.lengthM, o.widthM, o.heightM)}tight box from the object’s own principal axes.`),
+      this._row('Largest dimension', f.len(metrics.longestDimensionM),
         'Longest side of the oriented box — the headline size figure.'),
-      this._row('Axis-aligned',
-        `${m1(a.lengthM)} × ${m1(a.widthM)} × ${m1(a.heightM)} m`,
-        `${metresToFeet(a.lengthM).toFixed(1)} × ${metresToFeet(a.widthM).toFixed(1)} × ${metresToFeet(a.heightM).toFixed(1)} ft — box aligned to the scan axes.`),
-      this._row('Envelope volume', volMftFine(metrics.envelopeVolumeM3),
+      this._row('Axis-aligned', f.triple(a.lengthM, a.widthM, a.heightM),
+        `${f.tripleHint(a.lengthM, a.widthM, a.heightM)}box aligned to the scan axes.`),
+      this._row('Envelope volume', f.volFine(metrics.envelopeVolumeM3),
         OBJECT_ENVELOPE_VOLUME_HINT),
-      this._row('Bounding surface area', areaMftFine(metrics.surfaceAreaM2),
+      this._row('Bounding surface area', f.areaFine(metrics.surfaceAreaM2),
         OBJECT_SURFACE_AREA_HINT),
-      this._row('Points · spacing', `${metrics.pointCount.toLocaleString()} · ~${cm(metrics.medianSpacingM)}`),
+      this._row('Points · spacing', `${metrics.pointCount.toLocaleString()} · ~${f.spacing(metrics.medianSpacingM)}`),
       // Was "Scan completeness", which read as capture completeness. The ratio
       // bins directions about the centroid, so its ceiling is the shape of the
       // point set, not how much of the object was scanned.
       this._row(ANGULAR_COVERAGE_LABEL, `${Math.round(metrics.completenessPct)}% of directions`,
         ANGULAR_COVERAGE_HINT),
     );
-    // Only a scan that COULD reach full angular coverage can be short of it. A
-    // sheet never can, so warning about its underside invents a capture defect.
-    if (metrics.completenessPct < 65 && !isSheetLikeScan(metrics.obb)) {
-      this._body.append(el('div', {
-        className: 'olv-object-note is-warn',
-        text: 'Parts of the surface (often the underside / occluded sides) were not captured.',
-      }));
-    }
     if (space) {
-      this._quality(space.quality);
+      this._quality(space.quality, f);
       this._caveats(space.reasons);
     }
     // Object export row: Report PDF only (no floor plan for objects).

--- a/tests/objectMetricsUnitNormalisation.test.ts
+++ b/tests/objectMetricsUnitNormalisation.test.ts
@@ -1,0 +1,134 @@
+/**
+ * objectMetricsUnitNormalisation.test.ts
+ *
+ * Object mode measured whatever numbers the file carried and printed them as
+ * metres. On a foot CRS every Object-panel figure was a foot figure wearing a
+ * metre label: 3.2808x on lengths, 10.764x on areas, 35.315x on volumes.
+ *
+ * The fix normalises the positions to metres BEFORE objectMetrics runs, using
+ * the same scale authority spaceMetrics uses, and only when the CRS actually
+ * resolved a linear unit. These tests pin both halves: the metre/foot
+ * equivalence of the measured figures, and the panel's refusal to print a
+ * metre claim when the unit is unknown.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { objectMetrics } from '../src/terrain/objectMetrics';
+import { resolveLinearUnitScale, spaceMetrics } from '../src/terrain/spaceMetrics';
+import { positionsInMetres, scalePositions } from '../src/terrain/sourceScale';
+
+const M_PER_FT = 0.3048;
+
+/** A hollow box shell, 4 x 2 x 1 metres, sampled on a regular grid. */
+function shellMetres(step = 0.1): Float32Array {
+  const t: number[] = [];
+  const push = (x: number, y: number, z: number): void => { t.push(x, y, z); };
+  for (let x = 0; x <= 4 + 1e-9; x += step)
+    for (let y = 0; y <= 2 + 1e-9; y += step) { push(x, y, 0); push(x, y, 1); }
+  for (let x = 0; x <= 4 + 1e-9; x += step)
+    for (let z = 0; z <= 1 + 1e-9; z += step) { push(x, 0, z); push(x, 2, z); }
+  for (let y = 0; y <= 2 + 1e-9; y += step)
+    for (let z = 0; z <= 1 + 1e-9; z += step) { push(0, y, z); push(4, y, z); }
+  return Float32Array.from(t);
+}
+
+describe('object metrics are normalised to metres before measuring', () => {
+  const metres = shellMetres();
+  const feet = scalePositions(metres, 1 / M_PER_FT);
+
+  it('the same object measured in metres and in feet reports the same figures', () => {
+    const a = objectMetrics(
+      positionsInMetres(metres, resolveLinearUnitScale(1, true)),
+      { sourcePointCount: metres.length / 3 },
+    );
+    const b = objectMetrics(
+      positionsInMetres(feet, resolveLinearUnitScale(M_PER_FT, true)),
+      { sourcePointCount: feet.length / 3 },
+    );
+    const rel = (x: number, y: number): number => Math.abs(x - y) / Math.max(1e-9, Math.abs(x));
+    for (const k of ['lengthM', 'widthM', 'heightM'] as const) {
+      expect(rel(a.obb[k], b.obb[k])).toBeLessThan(1e-4);
+      expect(rel(a.aabb[k], b.aabb[k])).toBeLessThan(1e-4);
+    }
+    expect(rel(a.longestDimensionM, b.longestDimensionM)).toBeLessThan(1e-4);
+    expect(rel(a.medianSpacingM, b.medianSpacingM)).toBeLessThan(1e-4);
+    expect(rel(a.surfaceAreaM2, b.surfaceAreaM2)).toBeLessThan(1e-4);
+    expect(rel(a.envelopeVolumeM3, b.envelopeVolumeM3)).toBeLessThan(1e-4);
+    // And the metre run is the truth the figures are compared against.
+    expect(a.longestDimensionM).toBeCloseTo(4, 2);
+  });
+
+  it('an unknown linear unit is left in source units, never scaled', () => {
+    const same = positionsInMetres(feet, resolveLinearUnitScale(M_PER_FT, false));
+    expect(same[0]).toBe(feet[0]);
+    expect(same[300]).toBe(feet[300]);
+  });
+});
+
+// ── The panel must not print a metre claim it cannot support ────────────────
+class FakeEl {
+  className = '';
+  title = '';
+  type = '';
+  disabled = false;
+  private _text = '';
+  readonly children: FakeEl[] = [];
+  readonly dataset: Record<string, string> = {};
+  readonly classList = { toggle(): void { /* no-op */ }, remove(): void { /* no-op */ } };
+  readonly tagName: string;
+  constructor(tagName: string) { this.tagName = tagName; }
+  setAttribute(): void { /* no-op */ }
+  removeAttribute(): void { /* no-op */ }
+  set textContent(v: string) { this._text = v; }
+  get textContent(): string {
+    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
+  }
+  append(...kids: FakeEl[]): void { this.children.push(...kids); }
+  replaceChildren(...kids: FakeEl[]): void { this.children.length = 0; this.children.push(...kids); }
+  addEventListener(): void { /* no-op */ }
+}
+
+/** Every title/hint string in the rendered tree, joined. */
+function allTitles(root: FakeEl, acc: string[] = []): string[] {
+  if (root.title) acc.push(root.title);
+  for (const c of root.children) allTitles(c, acc);
+  return acc;
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { document: unknown }).document = {
+    createElement: (tag: string) => new FakeEl(tag),
+  };
+});
+
+describe('ObjectPanel - an unknown unit prints no metre, foot or centimetre claim', () => {
+  it('renders source-unit figures only', async () => {
+    const { ObjectPanel } = await import('../src/ui/ObjectPanel');
+    const positions = shellMetres(0.2);
+    const space = spaceMetrics(positions, {
+      upAxis: 'z', spaceKind: 'object', unitToMetres: 1, unitKnown: false,
+      sourcePointCount: positions.length / 3,
+    });
+    const panel = new ObjectPanel();
+    panel.showObject(objectMetrics(positions), space, null);
+    const root = panel.element as unknown as FakeEl;
+    const text = `${root.textContent} ${allTitles(root).join(' ')}`;
+    expect(text).not.toMatch(/\d\s*(m|ft|cm|m²|ft²|m³|ft³)\b/);
+    expect(text).not.toContain('pts/m²');
+    expect(text).toContain('source units');
+  });
+
+  it('a known foot CRS still prints metres with the foot conversion', async () => {
+    const { ObjectPanel } = await import('../src/ui/ObjectPanel');
+    const positions = shellMetres(0.2);
+    const space = spaceMetrics(positions, {
+      upAxis: 'z', spaceKind: 'object', unitToMetres: M_PER_FT, unitKnown: true,
+      sourcePointCount: positions.length / 3,
+    });
+    const panel = new ObjectPanel();
+    panel.showObject(objectMetrics(positions), space, null);
+    const text = (panel.element as unknown as FakeEl).textContent;
+    expect(text).toMatch(/\bm\b/);
+    expect(text).toMatch(/\bft\b/);
+  });
+});

--- a/tests/objectMetricsUnitNormalisation.test.ts
+++ b/tests/objectMetricsUnitNormalisation.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { objectMetrics } from '../src/terrain/objectMetrics';
 import { resolveLinearUnitScale, spaceMetrics } from '../src/terrain/spaceMetrics';
 import { positionsInMetres, scalePositions } from '../src/terrain/sourceScale';
@@ -130,5 +131,27 @@ describe('ObjectPanel - an unknown unit prints no metre, foot or centimetre clai
     const text = (panel.element as unknown as FakeEl).textContent;
     expect(text).toMatch(/\bm\b/);
     expect(text).toMatch(/\bft\b/);
+  });
+});
+
+describe('the call site itself is normalised, not just the helper', () => {
+  // The defect was never in objectMetrics; it was that main.ts handed it raw
+  // source-unit positions while spaceMetrics scaled the same buffer first.
+  // Both accept `Float32Array | ReadonlyArray<number>`, so removing the wrapper
+  // type-checks and every helper test still passes. This reads the wiring.
+  const main = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8');
+
+  it('passes objectMetrics positions converted to metres', () => {
+    const call = /objectMetrics\(\s*([^,]+),/.exec(main);
+    expect(call, 'objectMetrics call site not found in main.ts').toBeTruthy();
+    expect(call![1]).toMatch(/positionsInMetres\(/);
+  });
+
+  it('resolves the scale from the CRS unit-known flag, not the bare factor', () => {
+    expect(main).toMatch(/resolveLinearUnitScale\(\s*unitToMetres,\s*spaceCtx\.linearUnitKnown\s*\)/);
+  });
+
+  it('never hands objectMetrics the raw gathered buffer', () => {
+    expect(main).not.toMatch(/objectMetrics\(\s*gathered\.positions/);
   });
 });

--- a/tests/objectPanelSpace.test.ts
+++ b/tests/objectPanelSpace.test.ts
@@ -122,7 +122,11 @@ describe('ObjectPanel — space / object routing', () => {
     const { spaceMetrics } = await import('../src/terrain/spaceMetrics');
 
     const pos = cubeShell();
-    const space = spaceMetrics(pos, { upAxis: 'z', spaceKind: 'object', hasRgb: true });
+    // A DECLARED metre CRS: the metric render is only honest when the unit
+    // authority actually resolved a linear unit.
+    const space = spaceMetrics(pos, {
+      upAxis: 'z', spaceKind: 'object', hasRgb: true, unitToMetres: 1, unitKnown: true,
+    });
 
     const panel = new ObjectPanel();
     panel.showObject(objectMetrics(pos), space, null);
@@ -262,11 +266,12 @@ describe('ObjectPanel — space / object routing', () => {
 
 // ── Angular coverage is a shape signature, not a capture defect ─────────────
 // The panel warned "Parts of the surface (often the underside / occluded sides)
-// were not captured." below 65%. A sheet-like scan bins into the near-equatorial
-// band only, so it can never clear 65% however completely it was captured, and
-// the warning fabricated a defect report for a complete tile.
-describe('ObjectPanel - the occlusion warning is gated on shape', () => {
-  const OCCLUSION_WARNING = 'Parts of the surface';
+// were not captured." below 65%. The statistic is angular coverage about the
+// centroid, which a concave, elongated, open or anisotropically sampled object
+// depresses just as readily as occlusion does. It cannot separate those causes,
+// so no capture conclusion is drawn from it at any value.
+describe('ObjectPanel - angular coverage draws no capture conclusion', () => {
+  const CAPTURE_CLAIM = /were not captured|underside|occluded/i;
 
   /** Hand-built metrics: the gate is about labels, never the computation. */
   function box(L: number, W: number, H: number, coveragePct: number): {
@@ -291,31 +296,36 @@ describe('ObjectPanel - the occlusion warning is gated on shape', () => {
     };
   }
 
-  it('a sheet-like scan at 56% gets no occlusion warning', async () => {
+  async function render(L: number, W: number, H: number, pct: number): Promise<string> {
     const { ObjectPanel } = await import('../src/ui/ObjectPanel');
     const panel = new ObjectPanel();
+    panel.showObject(box(L, W, H, pct), null, null);
+    const root = panel.element as unknown as FakeEl;
+    const titles = flatten(root).map((e) => e.title).filter(Boolean).join(' ');
+    return `${root.textContent} ${titles}`;
+  }
+
+  it('a low-coverage sheet draws no missing-capture conclusion', async () => {
     // The field case: a 1270 x 977 x 268 m terrain tile reporting 56%.
-    panel.showObject(box(1270.87, 977.35, 268.22, 56), null, null);
-    const text = (panel.element as unknown as FakeEl).textContent;
-    expect(text).not.toContain(OCCLUSION_WARNING);
+    expect(await render(1270.87, 977.35, 268.22, 56)).not.toMatch(CAPTURE_CLAIM);
   });
 
-  it('a compact object that really is short of returns still gets it', async () => {
-    const { ObjectPanel } = await import('../src/ui/ObjectPanel');
-    const panel = new ObjectPanel();
-    panel.showObject(box(1.2, 1.1, 0.9, 41), null, null);
-    const text = (panel.element as unknown as FakeEl).textContent;
-    expect(text).toContain(OCCLUSION_WARNING);
+  it('a low-coverage compact object draws no missing-capture conclusion', async () => {
+    expect(await render(1.2, 1.1, 0.9, 41)).not.toMatch(CAPTURE_CLAIM);
   });
 
-  it('names the row angular coverage, never a completeness', async () => {
-    const { ObjectPanel } = await import('../src/ui/ObjectPanel');
-    const { ANGULAR_COVERAGE_LABEL } = await import('../src/terrain/objectMetrics');
-    const panel = new ObjectPanel();
-    panel.showObject(box(1.2, 1.1, 0.9, 88), null, null);
-    const text = (panel.element as unknown as FakeEl).textContent;
-    expect(text).toContain(ANGULAR_COVERAGE_LABEL);
-    expect(text).not.toMatch(/completeness/i);
+  it('a high-coverage object makes no completeness claim either', async () => {
+    expect(await render(1.2, 1.1, 0.9, 88)).not.toMatch(/completeness/i);
+  });
+
+  it('every case shows the angular coverage label and its basis', async () => {
+    const { ANGULAR_COVERAGE_LABEL, ANGULAR_COVERAGE_HINT } =
+      await import('../src/terrain/objectMetrics');
+    for (const pct of [41, 56, 88]) {
+      const text = await render(1.2, 1.1, 0.9, pct);
+      expect(text).toContain(ANGULAR_COVERAGE_LABEL);
+      expect(text).toContain(ANGULAR_COVERAGE_HINT);
+    }
   });
 });
 


### PR DESCRIPTION
`spaceMetrics` scales source units to metres before measuring; `main.ts` handed `objectMetrics` the raw gathered buffer, and `objectMetrics` has no unit parameter because it assumes metres. On a foot CRS the Object panel and the cached PDF export therefore reported feet as metres: 3.28x on length, 10.76x on area, 35.32x on volume.

Both call sites now use one helper, `positionsInMetres`, and scaling happens only when the CRS unit is known. With an unknown unit the panel prints source units and drops the foot conversion instead of inventing one.

The angular-coverage warning is removed. A low value can come from object shape, concavity, occlusion or incomplete capture, and the statistic cannot tell them apart; the sheet-like exception only masked one case.
