### PR TITLE
test(measure): share the object-panel DOM stub across its three suites

### DIFF
--- a/tests/objectMetricsUnitNormalisation.test.ts
+++ b/tests/objectMetricsUnitNormalisation.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
+import { FakeEl, allTitles } from './support/objectPanelDom';
 import { readFileSync } from 'node:fs';
 import { objectMetrics } from '../src/terrain/objectMetrics';
 import { resolveLinearUnitScale, spaceMetrics } from '../src/terrain/spaceMetrics';
@@ -67,34 +68,7 @@ describe('object metrics are normalised to metres before measuring', () => {
 });
 
 // ── The panel must not print a metre claim it cannot support ────────────────
-class FakeEl {
-  className = '';
-  title = '';
-  type = '';
-  disabled = false;
-  private _text = '';
-  readonly children: FakeEl[] = [];
-  readonly dataset: Record<string, string> = {};
-  readonly classList = { toggle(): void { /* no-op */ }, remove(): void { /* no-op */ } };
-  readonly tagName: string;
-  constructor(tagName: string) { this.tagName = tagName; }
-  setAttribute(): void { /* no-op */ }
-  removeAttribute(): void { /* no-op */ }
-  set textContent(v: string) { this._text = v; }
-  get textContent(): string {
-    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
-  }
-  append(...kids: FakeEl[]): void { this.children.push(...kids); }
-  replaceChildren(...kids: FakeEl[]): void { this.children.length = 0; this.children.push(...kids); }
-  addEventListener(): void { /* no-op */ }
-}
 
-/** Every title/hint string in the rendered tree, joined. */
-function allTitles(root: FakeEl, acc: string[] = []): string[] {
-  if (root.title) acc.push(root.title);
-  for (const c of root.children) allTitles(c, acc);
-  return acc;
-}
 
 beforeAll(() => {
   (globalThis as unknown as { document: unknown }).document = {

--- a/tests/objectPanelExport.test.ts
+++ b/tests/objectPanelExport.test.ts
@@ -8,35 +8,8 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
+import { FakeEl } from './support/objectPanelDom';
 
-class FakeEl {
-  className = '';
-  title = '';
-  type = '';
-  disabled = false;
-  private _text = '';
-  readonly children: FakeEl[] = [];
-  readonly dataset: Record<string, string> = {};
-  readonly classList = { toggle(): void { /* no-op */ } };
-  readonly tagName: string;
-  constructor(tagName: string) { this.tagName = tagName; }
-  setAttribute(): void { /* no-op */ }
-  removeAttribute(): void { /* no-op */ }
-  set textContent(v: string) { this._text = v; }
-  get textContent(): string {
-    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
-  }
-  append(...kids: FakeEl[]): void { this.children.push(...kids); }
-  replaceChildren(...kids: FakeEl[]): void { this.children.length = 0; this.children.push(...kids); }
-  addEventListener(): void { /* no-op */ }
-  /** Recursively collect every descendant whose textContent equals `label`. */
-  findByText(label: string): FakeEl[] {
-    const out: FakeEl[] = [];
-    if (this._text === label) out.push(this);
-    for (const c of this.children) out.push(...c.findByText(label));
-    return out;
-  }
-}
 
 beforeAll(() => {
   (globalThis as unknown as { document: unknown }).document = {

--- a/tests/objectPanelSpace.test.ts
+++ b/tests/objectPanelSpace.test.ts
@@ -9,29 +9,9 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
+import { FakeEl } from './support/objectPanelDom';
 
 /** A tiny fake element supporting only the surface ObjectPanel touches. */
-class FakeEl {
-  className = '';
-  title = '';
-  type = '';
-  disabled = false;
-  private _text = '';
-  readonly children: FakeEl[] = [];
-  readonly dataset: Record<string, string> = {};
-  readonly classList = { toggle(): void { /* no-op */ } };
-  readonly tagName: string;
-  constructor(tagName: string) { this.tagName = tagName; }
-  setAttribute(): void { /* no-op */ }
-  removeAttribute(): void { /* no-op */ }
-  set textContent(v: string) { this._text = v; }
-  get textContent(): string {
-    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
-  }
-  append(...kids: FakeEl[]): void { this.children.push(...kids); }
-  replaceChildren(...kids: FakeEl[]): void { this.children.length = 0; this.children.push(...kids); }
-  addEventListener(): void { /* no-op */ }
-}
 
 /** Depth-first flatten of a FakeEl tree (self included). */
 function flatten(root: FakeEl, acc: FakeEl[] = []): FakeEl[] {

--- a/tests/support/objectPanelDom.ts
+++ b/tests/support/objectPanelDom.ts
@@ -1,0 +1,43 @@
+/**
+ * objectPanelDom.ts — the DOM stub the Object/Space panel tests share.
+ *
+ * ObjectPanel asserts on RENDERED text, so this stub's `textContent` flattens
+ * its children, which the general `measurePanelDom` FakeEl does not do. Three
+ * test files had declared it independently, which Sonar counted as duplicated
+ * lines on every new object-panel test.
+ */
+export class FakeEl {
+  className = '';
+  title = '';
+  type = '';
+  disabled = false;
+  private _text = '';
+  readonly children: FakeEl[] = [];
+  readonly dataset: Record<string, string> = {};
+  readonly classList = { toggle(): void { /* no-op */ }, remove(): void { /* no-op */ } };
+  readonly tagName: string;
+  constructor(tagName: string) { this.tagName = tagName; }
+  setAttribute(): void { /* no-op */ }
+  removeAttribute(): void { /* no-op */ }
+  set textContent(v: string) { this._text = v; }
+  get textContent(): string {
+    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
+  }
+  append(...kids: FakeEl[]): void { this.children.push(...kids); }
+  replaceChildren(...kids: FakeEl[]): void { this.children.length = 0; this.children.push(...kids); }
+  /** Every node in this subtree whose own text equals `label`. */
+  findByText(label: string): FakeEl[] {
+    const out: FakeEl[] = [];
+    if (this._text === label) out.push(this);
+    for (const c of this.children) out.push(...c.findByText(label));
+    return out;
+  }
+  addEventListener(): void { /* no-op */ }
+}
+
+/** Every title/hint string in the rendered tree, joined. */
+export function allTitles(root: FakeEl, acc: string[] = []): string[] {
+  if (root.title) acc.push(root.title);
+  for (const c of root.children) allTitles(c, acc);
+  return acc;
+}


### PR DESCRIPTION
Three object-panel suites each declared their own DOM stub: `objectMetricsUnitNormalisation`, `objectPanelSpace` and `objectPanelExport`. Sonar counted the shared 12 lines as duplicated new code on #906, and it will do so again for the next object-panel test anyone adds.

`tests/support/objectPanelDom.ts` now holds the superset. It cannot reuse the general `measurePanelDom` stub, because these suites assert on rendered text and need a `textContent` that flattens children, which that one does not provide. The shared version keeps that recursive getter plus `classList.remove` and the `findByText` helper the export suite had.

The call-site guard added with the unit fix still fails when the wiring is reverted, so the dedupe does not weaken it.
