### PR TITLE
fix(ooc): serialise cache-map read-modify-write under a lock

### DIFF
--- a/src/app/heavyLasExecutor.ts
+++ b/src/app/heavyLasExecutor.ts
@@ -34,7 +34,7 @@ import {
 import { fingerprintFromRange, sourceContentDigestFromRange } from '../io/heavy/fileFingerprint';
 import {
   readCacheMap,
-  writeCacheMap,
+  mutateCacheMap,
   lookupEntry,
   verifiedEntry,
   upsertEntry,
@@ -254,6 +254,7 @@ async function tryReopen(
   file: File,
   deps: HeavyLasBridgeDeps,
   signal: AbortSignal,
+  locks: ReturnType<typeof resolveLockManager>,
 ): Promise<HeavyOpenResult | null> {
   const map = await readCacheMap(root);
   // Reuse is authorised by the whole-file content digest, not the quick locator:
@@ -265,7 +266,9 @@ async function tryReopen(
   if (!opened) {
     // The map named a store that is no longer usable; drop the stale entry so a
     // later open does not keep chasing it, then build fresh.
-    await writeCacheMap(root, removeByStoreName(map, entry.storeName)).catch(() => {});
+    await mutateCacheMap(locks, root, (current) =>
+      removeByStoreName(current, entry.storeName),
+    ).catch(() => {});
     return null;
   }
   try {
@@ -276,9 +279,8 @@ async function tryReopen(
     if (deps.debug) console.warn('[heavy-las] cache reopen attach failed; rebuilding', err);
     return null;
   }
-  await writeCacheMap(
-    root,
-    touchEntry(map, sourceContentSha256, generation, Date.now()),
+  await mutateCacheMap(locks, root, (current) =>
+    touchEntry(current, sourceContentSha256, generation, Date.now()),
   ).catch(() => {});
   return { status: 'attached', source: opened.source, decoder: opened.decoder };
 }
@@ -302,24 +304,32 @@ async function recordAndEvict(
   try {
     const now = Date.now();
     const tileBytes = reader.manifest.pointCount * reader.recordBytes;
-    let map = upsertEntry(await readCacheMap(root), {
-      fingerprint,
-      sourceContentSha256,
-      storeName,
-      generation,
-      createdAt: now,
-      lastUsedAt: now,
-      pointCount: reader.manifest.pointCount,
-      tileBytes,
-    });
-    const live = await liveStoreNames(locks);
-    if (live) {
-      for (const name of selectEvictions(map.entries, { budgetBytes: CACHE_BUDGET_BYTES, liveNames: live })) {
-        await removeOpfsStore(root, name).catch(() => {});
-        map = removeByStoreName(map, name);
+    // Record and evict as ONE locked read-modify-write. Two tabs promoting
+    // stores at the same time otherwise both read the same map and the second
+    // write drops the first tab's entry, orphaning a store that is retained on
+    // disk but referenced by nothing. Eviction belongs inside the same lock: it
+    // deletes stores, so two concurrent passes could each decide to remove what
+    // the other just recorded.
+    await mutateCacheMap(locks, root, async (current) => {
+      let map = upsertEntry(current, {
+        fingerprint,
+        sourceContentSha256,
+        storeName,
+        generation,
+        createdAt: now,
+        lastUsedAt: now,
+        pointCount: reader.manifest.pointCount,
+        tileBytes,
+      });
+      const live = await liveStoreNames(locks);
+      if (live) {
+        for (const name of selectEvictions(map.entries, { budgetBytes: CACHE_BUDGET_BYTES, liveNames: live })) {
+          await removeOpfsStore(root, name).catch(() => {});
+          map = removeByStoreName(map, name);
+        }
       }
-    }
-    await writeCacheMap(root, map);
+      return map;
+    });
     return true;
   } catch {
     return false;
@@ -405,7 +415,7 @@ export async function executeHeavyLasBuild(
       const digest = await sourceDigest();
       if (signal.aborted) return { status: 'cancelled' };
       if (digest) {
-        const reopened = await tryReopen(root, generation, digest, file, deps, signal);
+        const reopened = await tryReopen(root, generation, digest, file, deps, signal, resolveLockManager());
         if (reopened) return reopened;
       }
     }

--- a/src/io/heavy/oocCacheMap.ts
+++ b/src/io/heavy/oocCacheMap.ts
@@ -26,6 +26,7 @@ import { canonicalJson } from '../../canonicalHash';
 import { TILE_STORE_SCHEMA_VERSION } from './tileStore';
 import { FINGERPRINT_VERSION } from './fileFingerprint';
 import { readOpfsText, writeOpfsText, type OpfsDirHandle } from './opfsSpillStore';
+import { withCacheMapLock, type LockManagerLike } from './oocStoreLiveness';
 
 /** Bumped when the map's own shape changes, so an old record parses to empty.
  *  v2 adds the authoritative `sourceContentSha256` to every entry. */
@@ -237,4 +238,21 @@ export async function readCacheMap(root: OpfsDirHandle): Promise<OocCacheMap> {
 /** Write the map to the OPFS root (atomic via the OPFS writable swap). */
 export async function writeCacheMap(root: OpfsDirHandle, map: OocCacheMap): Promise<void> {
   await writeOpfsText(root, CACHE_MAP_FILE, serializeCacheMap(map));
+}
+
+/**
+ * Atomically apply `mutate` to the persisted map: re-read INSIDE the lock, so
+ * the write is based on what is on disk now rather than on a copy read before
+ * the lock was taken. Callers that hold a map read from earlier must not pass it
+ * in; that stale copy is what the lock exists to discard.
+ */
+export async function mutateCacheMap(
+  locks: LockManagerLike | null,
+  root: OpfsDirHandle,
+  mutate: (current: OocCacheMap) => OocCacheMap | Promise<OocCacheMap>,
+): Promise<void> {
+  await withCacheMapLock(locks, async () => {
+    const next = await mutate(await readCacheMap(root));
+    await writeCacheMap(root, next);
+  });
 }

--- a/src/io/heavy/oocStoreLiveness.ts
+++ b/src/io/heavy/oocStoreLiveness.ts
@@ -48,6 +48,34 @@ export function storeLockName(storeName: string): string {
   return `${LOCK_PREFIX}${storeName}`;
 }
 
+/**
+ * The lock the cache MAP file is mutated under. Distinct from any store's own
+ * lock: a store lock is held shared for as long as a tab keeps that store open,
+ * whereas this one is taken exclusively for the moment a read-modify-write of
+ * `ooc-cache-map.json` takes, and released immediately.
+ */
+const MAP_LOCK_NAME = `${LOCK_PREFIX}cache-map`;
+
+/**
+ * Run a cache-map read-modify-write under an exclusive lock.
+ *
+ * Without this, two tabs opening heavy files concurrently interleave as
+ * read(M0) / read(M0) / write(M1) / write(M0+own), and the first tab's committed
+ * entry is lost even though its store was promoted and retained — a store on
+ * disk that no map references, reclaimed only by the janitor's stale sweep.
+ *
+ * With no lock manager the body still runs, unguarded. That is exactly the
+ * behaviour before this lock existed, so a browser without Web Locks is no worse
+ * off; it is not a silent correctness claim.
+ */
+export function withCacheMapLock<T>(
+  locks: LockManagerLike | null,
+  body: () => Promise<T>,
+): Promise<T> {
+  if (!locks) return body();
+  return locks.request(MAP_LOCK_NAME, { mode: 'exclusive' }, () => body());
+}
+
 /** The store name behind a lock name, or null if it is not one of ours. */
 function storeNameFromLock(lockName: string): string | null {
   return lockName.startsWith(LOCK_PREFIX) ? lockName.slice(LOCK_PREFIX.length) : null;

--- a/src/io/heavy/storagePreflight.ts
+++ b/src/io/heavy/storagePreflight.ts
@@ -42,8 +42,8 @@
  * is the largest tile rather than a second store, which the reserve below
  * already covers many times over.
  *
- * Nothing in the application calls this yet. It is the check that has to exist
- * before any file is routed to local indexing, not the routing itself.
+ * `heavyLasExecutor` runs this before every index build, so a file is routed to
+ * local indexing only once the space it needs has been accounted for.
  */
 
 import { formatByteSize } from '../formatByteSize';

--- a/tests/oocCacheMapConcurrency.test.ts
+++ b/tests/oocCacheMapConcurrency.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  emptyCacheMap,
+  mutateCacheMap,
+  readCacheMap,
+  upsertEntry,
+  writeCacheMap,
+} from '../src/io/heavy/oocCacheMap';
+import { withCacheMapLock, type LockManagerLike } from '../src/io/heavy/oocStoreLiveness';
+import { fakeOpfsDir } from './support/fakeOpfs';
+
+/**
+ * Two tabs promoting stores at the same time used to interleave as
+ * read(M0) / read(M0) / write(M1) / write(M0+own): the first tab's entry
+ * vanished from the map while its store stayed on disk, retained and
+ * referenced by nothing.
+ */
+
+/** A Web Locks stand-in with real exclusive queuing, so interleaving is decided by the lock. */
+function fakeLocks(): LockManagerLike {
+  const chain = new Map<string, Promise<unknown>>();
+  return {
+    request<T>(name: string, _o: unknown, cb: (l: { name: string } | null) => T | Promise<T>) {
+      const prior = chain.get(name) ?? Promise.resolve();
+      const run = prior.then(() => cb({ name }));
+      chain.set(name, run.catch(() => undefined));
+      return run as Promise<T>;
+    },
+    query: () => Promise.resolve({ held: [] }),
+  };
+}
+
+const entry = (storeName: string) => ({
+  fingerprint: `fp-${storeName}`,
+  sourceContentSha256: `sha-${storeName}`,
+  storeName,
+  generation: 'g1',
+  createdAt: 1,
+  lastUsedAt: 1,
+  pointCount: 10,
+  tileBytes: 100,
+});
+
+/** Read, yield to the microtask queue, then write — the interleaving window. */
+async function unguardedUpsert(dir: ReturnType<typeof fakeOpfsDir>, name: string): Promise<void> {
+  const map = await readCacheMap(dir);
+  await Promise.resolve();
+  await writeCacheMap(dir, upsertEntry(map, entry(name)));
+}
+
+describe('cache-map concurrent mutation', () => {
+  it('loses an entry when two writers interleave unguarded', async () => {
+    const dir = fakeOpfsDir();
+    await writeCacheMap(dir, emptyCacheMap());
+    await Promise.all([unguardedUpsert(dir, 'store-a'), unguardedUpsert(dir, 'store-b')]);
+    const names = (await readCacheMap(dir)).entries.map((e) => e.storeName);
+    // The bug, pinned: one of the two writes is gone.
+    expect(names.length).toBe(1);
+  });
+
+  it('keeps both entries when each write re-reads under the lock', async () => {
+    const dir = fakeOpfsDir();
+    const locks = fakeLocks();
+    await writeCacheMap(dir, emptyCacheMap());
+    await Promise.all([
+      mutateCacheMap(locks, dir, async (m) => {
+        await Promise.resolve();
+        return upsertEntry(m, entry('store-a'));
+      }),
+      mutateCacheMap(locks, dir, async (m) => {
+        await Promise.resolve();
+        return upsertEntry(m, entry('store-b'));
+      }),
+    ]);
+    const names = (await readCacheMap(dir)).entries.map((e) => e.storeName).sort();
+    expect(names).toEqual(['store-a', 'store-b']);
+  });
+
+  it('runs the body unguarded when no lock manager exists, rather than refusing', async () => {
+    const dir = fakeOpfsDir();
+    await writeCacheMap(dir, emptyCacheMap());
+    await mutateCacheMap(null, dir, (m) => upsertEntry(m, entry('store-solo')));
+    expect((await readCacheMap(dir)).entries.map((e) => e.storeName)).toEqual(['store-solo']);
+  });
+
+  it('serialises bodies under the same lock name', async () => {
+    const locks = fakeLocks();
+    const order: string[] = [];
+    const body = (tag: string) => async () => {
+      order.push(`${tag}:enter`);
+      await Promise.resolve();
+      order.push(`${tag}:exit`);
+    };
+    await Promise.all([withCacheMapLock(locks, body('a')), withCacheMapLock(locks, body('b'))]);
+    expect(order).toEqual(['a:enter', 'a:exit', 'b:enter', 'b:exit']);
+  });
+});


### PR DESCRIPTION
Three sites in `heavyLasExecutor` read `ooc-cache-map.json`, mutated the copy and
wrote it back with nothing serialising them. Two tabs opening heavy files at once
interleave as read(M0) / read(M0) / write(M1) / write(M0+own), so the first tab's
entry is dropped while its store stays promoted and retained: a store on disk
that no map references, reclaimed only by the janitor's six-hour sweep.

`mutateCacheMap` re-reads inside an exclusive Web Lock, the same manager the
per-store residency already uses. Eviction moves inside that lock too, since it
deletes stores and two passes could each remove what the other recorded. Without
a lock manager the body still runs unguarded, which is what happened before.

The map had no concurrency test; the new one reproduces the lost update.
