### PR TITLE
fix(nav): stop a focused control's keys from also driving the camera

### DIFF
--- a/src/render/NavController.ts
+++ b/src/render/NavController.ts
@@ -837,9 +837,20 @@ export class NavController {
   // ─────────────────────────────────────────────────────────────────────────
 
   private _handleKeyDown(e: KeyboardEvent): void {
-    // Never steal keys while the user is typing in a form control.
+    // Never act on a key another control already handled. Tag-name matching
+    // alone cannot see a focused custom widget (the Measurements rail's resize
+    // grip is a div with role="separator"), so a widget that resized on an
+    // arrow key also orbited the camera. `defaultPrevented` is the general
+    // signal and covers every such control, present and future.
+    if (e.defaultPrevented) return;
+    // Never steal keys while the user is typing in a form control. contenteditable
+    // is a text surface too, and has no tag name of its own to match on.
     const el = document.activeElement;
     if (el && /^(INPUT|TEXTAREA|SELECT)$/.test(el.tagName)) return;
+    // Duck-typed, not `instanceof HTMLElement`: that constructor does not exist
+    // in the headless environment the nav tests run in, so the check threw
+    // there instead of falling through.
+    if ((el as { isContentEditable?: boolean } | null)?.isContentEditable === true) return;
     if (!this._hasCloud || !this._inputEnabled) return;
 
     // Mode + shortcut keys work in any mode. Digit4 joins the Digit1/2/3

--- a/src/ui/MeasurePanel.ts
+++ b/src/ui/MeasurePanel.ts
@@ -567,9 +567,15 @@ export class MeasurePanel {
       if (e.key === 'ArrowLeft') {
         this._setRailWidth(this._railWidthPx() - step);
         e.preventDefault();
+        // The grip consumed this key. Without stopping it, the event still
+        // reached NavController's window listener, whose focus guard tests
+        // INPUT/TEXTAREA/SELECT by tag name and so does not recognise a
+        // focused separator: the rail resized and the camera orbited at once.
+        e.stopPropagation();
       } else if (e.key === 'ArrowRight') {
         this._setRailWidth(this._railWidthPx() + step);
         e.preventDefault();
+        e.stopPropagation();
       }
     });
     return handle;

--- a/tests/resizeGripKeyCapture.test.ts
+++ b/tests/resizeGripKeyCapture.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Tab to the Measurements rail's resize grip and press ArrowLeft: the rail
+ * resized AND the camera orbited. The grip called `preventDefault` but let the
+ * event bubble, and NavController's window listener only recognised a typing
+ * surface by tag name — INPUT, TEXTAREA, SELECT — so a focused
+ * `div role="separator"` was not treated as holding focus.
+ *
+ * Source-level, because the panel needs a live viewer to render. Comments are
+ * stripped first: this repo has already had a source assertion kept green by
+ * prose that merely mentioned the property it was checking for.
+ */
+const stripComments = (s: string): string =>
+  s.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+
+const PANEL = stripComments(readFileSync(resolve(__dirname, '../src/ui/MeasurePanel.ts'), 'utf8'));
+const NAV = stripComments(readFileSync(resolve(__dirname, '../src/render/NavController.ts'), 'utf8'));
+
+describe('resize grip does not also drive the camera', () => {
+  it('stops the grip’s arrow keys from bubbling', () => {
+    // The handler body, from the keydown registration to the end of its block.
+    const start = PANEL.indexOf("handle.addEventListener('keydown'");
+    expect(start).toBeGreaterThan(-1);
+    const body = PANEL.slice(start, start + 900);
+    for (const arrow of ['ArrowLeft', 'ArrowRight']) {
+      const at = body.indexOf(arrow);
+      expect(at, arrow).toBeGreaterThan(-1);
+      // Each arrow branch must consume the event for itself AND stop it.
+      expect(body.slice(at, at + 260), arrow).toMatch(/stopPropagation\(\)/);
+    }
+  });
+
+  it('makes NavController ignore a key another control already handled', () => {
+    // Anchor on the METHOD, not the earlier registration that references it.
+    const at = NAV.indexOf('private _handleKeyDown(');
+    expect(at).toBeGreaterThan(-1);
+    const body = NAV.slice(at, at + 700);
+    expect(body).toMatch(/if\s*\(\s*e\.defaultPrevented\s*\)\s*return;/);
+    // The bare tag-name test must not be the ONLY focus guard any more.
+    expect(body).toMatch(/isContentEditable/);
+  });
+});


### PR DESCRIPTION
Tab to the Measurements rail's resize grip and press ArrowLeft: the rail resizes
and the camera orbits at the same time. The grip calls `preventDefault` but lets
the event bubble, and `NavController`'s focus guard recognises a typing surface
by tag name only, so a `div` with `role="separator"` does not count as holding
focus.

The grip now stops the arrow keys it consumes. `NavController` also returns on
`defaultPrevented`, which covers every such control rather than this one alone,
and treats a contenteditable as the text surface it is.

Both guards are duck-typed: `HTMLElement` does not exist in the environment the
nav tests run in, where an `instanceof` check threw instead of falling through.
